### PR TITLE
Fix issue with `lfe_eval:expr/2`

### DIFF
--- a/src/lfe_eval.erl
+++ b/src/lfe_eval.erl
@@ -437,8 +437,9 @@ add_expr_func(Name, Ar, Def, Env) ->
 
 eval_apply({expr,Func,Env}, Es, _) ->
     case lfe_macro:expand_expr_all(Func, Env) of
-	[lambda,Args|Body] -> apply_lambda(Args, Body, Es, Env);
-	['match-lambda'|Cls] -> apply_match_clauses(Cls, Es, Env)
+    [lambda,Args|Body] -> apply_lambda(Args, Body, Es, Env);
+    ['match-lambda'|Cls] -> apply_match_clauses(Cls, Es, Env);
+    Fun when erlang:is_function(Fun) -> erlang:apply(Fun, Es)
     end;
 eval_apply({letrec,Body,Fbs,Env}, Es, Ee) ->
     %% A function created by/for letrec-function.

--- a/test/eval_SUITE.lfe
+++ b/test/eval_SUITE.lfe
@@ -35,13 +35,13 @@
   (export (all 0) (suite 0) (groups 0) (init_per_suite 1) (end_per_suite 1)
 	  (init_per_group 2) (end_per_group 2)
 	  ;; (init_per_testcase 2) (end_per_testcase 2)
-	  (guard_1 1) (binary_1 1)))
+	  (guard_1 1) (binary_1 1) (binding_1 1)))
 
 (defmacro MODULE () `'eval_SUITE)
 
 (defun all ()
   ;; (: test_lib recompile (MODULE))
-  (list 'guard_1 'binary_1))
+  (list 'guard_1 'binary_1 'binding_1))
 
 ;;(defun suite () (list (tuple 'ct_hooks (list 'ts_install_cth))))
 (defun suite () ())
@@ -56,7 +56,7 @@
 
 (defun end_per_group (name config) config)
 
-(defun guard_1 
+(defun guard_1
   (['suite] ())
   (['doc] '"Guard tests.")
   ([config] (when (is_list config))
@@ -95,3 +95,16 @@
 			    (a #b(2 "AB" "CD"))))))
 
    'ok))
+
+(defun binding_1
+  (['suite] ())
+  (['doc] '"Test function bindings.")
+  ([config] (when (is_list config))
+    (let (((1 2)
+           (funcall (: lfe_eval expr
+             '(lambda () (foo 1 2))
+             ;; We evaluate the above lambda form in a new environment that
+             ;; contains a binding for the function foo/2.
+             (: lfe_eval add_expr_func 'foo 2 (lambda (a b) (list a b))
+               (: lfe_lib new_env))))))
+      'ok)))


### PR DESCRIPTION
This adds a case clause in `lfe_eval:eval_apply/3`, which fixes an
issue with `lfe_eval:expr/2`. The case clause is needed for calling
functions bound to the environment passed to `lfe_eval:expr/2`.
Without that case clause, calling a function bound to that very
environment causes a case clause error in `lfe_eval:eval_apply/3`.
