### PR TITLE
Rely on -user for lfe shell

### DIFF
--- a/bin/lfe
+++ b/bin/lfe
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 # Run LFE shell by default. Can add -pa if necessary.
-erl "$@" -noshell -noinput -s lfe_boot start
+erl -user lfe_boot "$@"


### PR DESCRIPTION
Use -user lfe_boot instead of -noshell and -noinput.

This allows standard input functions to still work with
lfe since input is still available. -noshell and -noinput
now can also be given by the developer in case he
wants to disable one or the other.

Besides, not using `-user` caused us a bunch of troubles
in Elixir. Since I used the lfe shell as basis to build elixir's
shell, I thought we should contribute our findings back.

This option works fine since R15, I did not check previous
versions. :) 
