### PR TITLE
Church encoding

### DIFF
--- a/examples/church.lfe
+++ b/examples/church.lfe
@@ -1,0 +1,101 @@
+;; Copyright (c) 2013 Duncan McGreggor <oubiwann@cogitat.io>
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; File    : church.lfe
+;; Author  : Duncan McGreggor
+;; Purpose : Demonstrating church numerals from the lambda calculus
+
+;; The code below was used to create the section of the user guide here:
+;;    http://lfe.github.io/user-guide/recursion/5.html
+;;
+;; Here is some example usage:
+;;
+;; > (slurp '"church.lfe")
+;; #(ok church)
+;; > (zero)
+;; #Fun<lfe_eval.10.53503600>
+;; > (church->int1 (zero))
+;; 0
+;; > (church->int1 (three))
+;; 3
+;; > (church->int1 (five))
+;; 5
+;; > (church->int2 #'five/0)
+;; 5
+;; > (church->int2 (lambda () (get-church 25)))
+;; 25
+
+(defmodule church
+  (export all))
+
+(defun zero ()
+  (lambda (s)
+    (lambda (x) x)))
+
+(defun one ()
+  (lambda (s)
+    (lambda (x)
+      (funcall s x))))
+
+(defun two ()
+  (lambda (s)
+    (lambda (x)
+      (funcall s
+        (funcall s x)))))
+
+(defun three ()
+  (lambda (s)
+    (lambda (x)
+      (funcall s
+        (funcall s
+          (funcall s x))))))
+
+(defun four ()
+  (lambda (s)
+    (lambda (x)
+      (funcall s
+        (funcall s
+          (funcall s
+            (funcall s x)))))))
+
+(defun five ()
+  (get-church 5))
+
+(defun int-successor (n)
+  (+ n 1))
+
+; converts a called church numeral to an integer, e.g.:
+;   > (church->int1 (five))
+(defun church->int1 (church-numeral)
+  (funcall (funcall church-numeral #'int-successor/1) 0))
+
+; converts a non-called church numeral to an integer, e.g.:
+;   > (church->int2 #'five/0)
+(defun church->int2 (church-numeral)
+  (funcall (funcall (funcall church-numeral) #'int-successor/1) 0))
+
+(defun church-successor (church-numeral)
+  (lambda (s)
+    (lambda (x)
+      (funcall s
+        (funcall
+          (funcall church-numeral s) x)))))
+
+(defun get-church (church-numeral count limit)
+  (cond ((== count limit) church-numeral)
+        ((/= count limit)
+         (get-church (church-successor church-numeral) (+ 1 count) limit))))
+
+(defun get-church (integer)
+  (get-church (zero) 0 integer))

--- a/examples/internal-state.lfe
+++ b/examples/internal-state.lfe
@@ -1,0 +1,105 @@
+;; Copyright (c) 2013 Duncan McGreggor <oubiwann@cogitat.io>
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; File    : internal-state.lfe
+;; Author  : Duncan McGreggor
+;; Purpose : Demonstrating keeping state with closures
+
+;; This file contains a conversion of some of the Common Lisp code from the
+;; beginning of Chapter 13 in Peter Norvig's "Paradigms of Artificial
+;; Intelligence Programming: Case Studies in Common Lisp".
+;;
+;; To use the code below in LFE, do the following:
+;;
+;;  $ cd examples
+;;  $ ../bin/lfe -pa ../ebin
+;;
+;; > (slurp '"internal-state.lfe")
+;; #(ok internal-state)
+;; > (set account (new-account '"Alice" 100.00 0.06))
+;; #Fun<lfe_eval.10.53503600>
+;; > (name account)
+;; "Alice"
+;; > (balance account)
+;; 100.0
+;; > (set account (interest account))
+;; #Fun<lfe_eval.10.53503600>
+;; > (balance account)
+;; 106.0
+;; > (set account (withdraw account 54.90))
+;; #Fun<lfe_eval.10.53503600>
+;; > (set account (withdraw account 54.90))
+;; exception error: insufficient-funds
+;;
+;; > (balance account)
+;; 51.1
+;; > (set account (deposit account 1000))
+;; #Fun<lfe_eval.10.53503600>
+;; > (set account (withdraw account 54.90))
+;; #Fun<lfe_eval.10.53503600>
+;; > (set account (withdraw account 54.90))
+;; #Fun<lfe_eval.10.53503600>
+;; > (set account (withdraw account 54.90))
+;; #Fun<lfe_eval.10.53503600>
+;; > (balance account)
+;; 886.4
+;; > (set account (interest account))
+;; #Fun<lfe_eval.10.53503600>
+;; > (balance account)
+;; 939.584
+
+(defmodule internal-state
+ (export all))
+
+(defun new-account (name balance interest-rate)
+  (lambda (message)
+    (case message
+      ('withdraw (lambda (amt)
+                    (if (=< amt balance)
+                        (new-account name (- balance amt) interest-rate)
+                        (: erlang error 'insufficient-funds))))
+      ('deposit (lambda (amt) (new-account name (+ balance amt) interest-rate)))
+      ('balance (lambda () balance))
+      ('name (lambda () name))
+      ('interest (lambda ()
+                    (new-account
+                      name
+                      (+ balance (* balance interest-rate))
+                      interest-rate))))))
+
+(defun get-method (object command)
+  (funcall object command))
+
+(defun send (object command arg)
+  (funcall (get-method object command) arg))
+
+; returns an updated account object
+(defun withdraw (object amt)
+  (funcall (get-method object 'withdraw) amt))
+
+; returns an updated account object
+(defun deposit (object amt)
+  (funcall (get-method object 'deposit) amt))
+
+; returns a float representing the balance
+(defun balance (object)
+  (funcall (get-method object 'balance)))
+
+; returns a string represnting the account holder
+(defun name (object)
+  (funcall (get-method object 'name)))
+
+; returns an updated account object
+(defun interest (object)
+  (funcall (get-method object 'interest)))


### PR DESCRIPTION
Added an example for the encoding of church numerals in LFE, converting these to integers, etc.

This is the code that was used when writing portions of this section of the new user guide:
  http://lfe.github.io/user-guide/recursion/5.html
