### PR TITLE
Fixup examples

### DIFF
--- a/examples/church.lfe
+++ b/examples/church.lfe
@@ -75,14 +75,16 @@
 (defun int-successor (n)
   (+ n 1))
 
-; converts a called church numeral to an integer, e.g.:
-;   > (church->int1 (five))
 (defun church->int1 (church-numeral)
+  "Converts a called church numeral to an integer, e.g.:
+     > (church->int1 (five))
+  "
   (funcall (funcall church-numeral #'int-successor/1) 0))
 
-; converts a non-called church numeral to an integer, e.g.:
-;   > (church->int2 #'five/0)
 (defun church->int2 (church-numeral)
+  "Converts a non-called church numeral to an integer, e.g.:
+     > (church->int2 #'five/0)
+  "
   (funcall (funcall (funcall church-numeral) #'int-successor/1) 0))
 
 (defun church-successor (church-numeral)

--- a/examples/core-macros.lfe
+++ b/examples/core-macros.lfe
@@ -68,12 +68,12 @@
 (defmacro let*
   ((cons (cons vb vbs) b) `(let (,vb) (let* ,vbs . ,b)))
   ((cons () b) `(progn . ,b))
-  ((cons vb b) `(let ,vb . b)))		;Pass error to let
+  ((cons vb b) `(let ,vb . b)))        ;Pass error to let
 
 (defmacro flet*
   ((cons (cons fb fbs) b) `(flet (,fb) (flet* ,fbs . ,b)))
   ((cons () b) `(progn . ,b))
-  ((cons fb b) `(flet ,fb . b)))		;Pass error to flet
+  ((cons fb b) `(flet ,fb . b)))        ;Pass error to flet
 
 (defmacro cond
   ((list (cons 'else b)) `(progn . ,b))
@@ -89,7 +89,7 @@
   ((cons e es) `(if ,e (andalso . ,es) 'false))
   (() `'true))
 
-(defmacro orelse args			;Using single argument
+(defmacro orelse args            ;Using single argument
   (case args
     ((list e) e)
     ((cons e es) `(if ,e 'true (orelse . ,es)))
@@ -106,39 +106,39 @@
   (defun bq-expand (exp n)
     ;; Note that we cannot *use* backquote or any macros using
     ;; backquote in here! It will cause us to loop.
-    (fletrec ((bq-app			;Optimise append
-	       ([(list '++ l) r] (bq-app l r)) ;Catch single unquote-splice
-	       ([() r] r)
-	       ([l ()] l)
-	       ([(list 'list l) (cons 'list r)] (cons 'list (cons l r)))
-	       ([(list 'list l) r] (list 'cons l r))
-	       ([l r] (list '++ l r)))
-	      (bq-cons			;Optimise cons
-	       ([(list 'quote l) (list 'quote r)] (list 'quote (cons l r)))
-	       ([l (cons 'list r)] (cons 'list (cons l r)))
-	       ([l ()] (list 'list l))
-	       ([l r] (list 'cons l r))))
+    (fletrec ((bq-app            ;Optimise append
+           ([(list '++ l) r] (bq-app l r)) ;Catch single unquote-splice
+           ([() r] r)
+           ([l ()] l)
+           ([(list 'list l) (cons 'list r)] (cons 'list (cons l r)))
+           ([(list 'list l) r] (list 'cons l r))
+           ([l r] (list '++ l r)))
+          (bq-cons            ;Optimise cons
+           ([(list 'quote l) (list 'quote r)] (list 'quote (cons l r)))
+           ([l (cons 'list r)] (cons 'list (cons l r)))
+           ([l ()] (list 'list l))
+           ([l r] (list 'cons l r))))
       (case exp
-	((list 'backquote x)	;`(list 'backquote ,(bq-expand x (+ n 1)))
-	 (list 'list (list 'quote 'backquote) (bq-expand x (+ n 1))))
-	((list 'unquote x) (when (> n 0))
-	 (bq-cons 'unquote (bq-expand x (- n 1))))
-	((list 'unquote x) (when (=:= n 0)) x)
-	((list 'unquote-splicing . x) (when (> n 0))
-	 (bq-cons (list 'quote 'unquote-splicing) (bq-expand x (- n 1))))
-	;; The next two cases handle splicing into a list.
-	(((list 'unquote . x) . y) (when (=:= n 0))
-	 (bq-app (cons 'list x) (bq-expand y 0)))
-	(((list 'unquote-splicing . x) . y) (when (=:= n 0))
-	 (bq-app (cons '++ x) (bq-expand y 0)))
-	((cons x y)			;The general list case
-	 (bq-cons (bq-expand x n) (bq-expand y n)))
-	(_ (when (is_tuple exp))
-	   ;; Tuples need some smartness for efficient code to handle
-	   ;; when no splicing so as to avoid list_to_tuple.
-	   (case (bq-expand (tuple_to_list exp) n)
-	     (('list . es) (cons tuple es))
-	     ((= ('cons . _) e) (list 'list_to_tuple e))))
-	(_ (when (is_atom exp)) (list 'quote exp))
-	(_ exp))			;Self quoting
+    ((list 'backquote x)    ;`(list 'backquote ,(bq-expand x (+ n 1)))
+     (list 'list (list 'quote 'backquote) (bq-expand x (+ n 1))))
+    ((list 'unquote x) (when (> n 0))
+     (bq-cons 'unquote (bq-expand x (- n 1))))
+    ((list 'unquote x) (when (=:= n 0)) x)
+    ((list 'unquote-splicing . x) (when (> n 0))
+     (bq-cons (list 'quote 'unquote-splicing) (bq-expand x (- n 1))))
+    ;; The next two cases handle splicing into a list.
+    (((list 'unquote . x) . y) (when (=:= n 0))
+     (bq-app (cons 'list x) (bq-expand y 0)))
+    (((list 'unquote-splicing . x) . y) (when (=:= n 0))
+     (bq-app (cons '++ x) (bq-expand y 0)))
+    ((cons x y)            ;The general list case
+     (bq-cons (bq-expand x n) (bq-expand y n)))
+    (_ (when (is_tuple exp))
+       ;; Tuples need some smartness for efficient code to handle
+       ;; when no splicing so as to avoid list_to_tuple.
+       (case (bq-expand (tuple_to_list exp) n)
+         (('list . es) (cons tuple es))
+         ((= ('cons . _) e) (list 'list_to_tuple e))))
+    (_ (when (is_atom exp)) (list 'quote exp))
+    (_ exp))            ;Self quoting
       )))

--- a/examples/ets_demo.lfe
+++ b/examples/ets_demo.lfe
@@ -31,45 +31,45 @@
 (defun new ()
   (let ((db (: ets new 'ets_demo '(#(keypos 2) set))))
     (let ((people '(
-		    ;; First some people in London.
-		    #(fred london waiter)
-		    #(bert london waiter)
-		    #(john london painter)
-		    #(paul london driver)
-		    ;; Now some in Paris.
-		    #(jean paris waiter)
-		    #(gerard paris driver)
-		    #(claude paris painter)
-		    #(yves paris waiter)
-		    ;; And some in Rome.
-		    #(roberto rome waiter)
-		    #(guiseppe rome driver)
-		    #(paulo rome painter)
-		    ;; And some in Berlin.
-		    #(fritz berlin painter)
-		    #(kurt berlin driver)
-		    #(hans berlin waiter)
-		    #(franz berlin waiter)
-		    )))
+            ;; First some people in London.
+            #(fred london waiter)
+            #(bert london waiter)
+            #(john london painter)
+            #(paul london driver)
+            ;; Now some in Paris.
+            #(jean paris waiter)
+            #(gerard paris driver)
+            #(claude paris painter)
+            #(yves paris waiter)
+            ;; And some in Rome.
+            #(roberto rome waiter)
+            #(guiseppe rome driver)
+            #(paulo rome painter)
+            ;; And some in Berlin.
+            #(fritz berlin painter)
+            #(kurt berlin driver)
+            #(hans berlin waiter)
+            #(franz berlin waiter)
+            )))
       (: lists foreach (match-lambda
-			 ([(tuple n p j)]
-			  (: ets insert db (make-person name n place p job j))))
-	 people))
-    db))				;Return the table
+             ([(tuple n p j)]
+              (: ets insert db (make-person name n place p job j))))
+     people))
+    db))                ;Return the table
 
 ;; Match records by place using match, match_object and the emp-XXXX macro.
 (defun by_place (db place)
   (let ((s1 (: ets match db (emp-person name '$1 place place job '$2)))
-	(s2 (: ets match_object db (emp-person place place))))
+    (s2 (: ets match_object db (emp-person place place))))
     (tuple s1 s2)))
 
 ;; Use match specifications to match records
 (defun by_place_ms (db place)
   (: ets select db (match-spec ([(match-person name n place p job j)]
-				(when (=:= place p))
-				(list 'p n j)))))
+                (when (=:= place p))
+                (list 'p n j)))))
 
 (defun not_painter (db place)
   (: ets select db (match-spec ([(match-person name n place p job j)]
-				(when (=:= place p) (=/= j 'painter))
-				(list 'p n j)))))
+                (when (=:= place p) (=/= j 'painter))
+                (list 'p n j)))))

--- a/examples/fizzbuzz.lfe
+++ b/examples/fizzbuzz.lfe
@@ -73,7 +73,7 @@
    ;; -> (tuple 'error '"Buzz/1 only accepts whole numbers > 0")
    ;;
    ;; Or if necessary you can trigger an Erlang error:
-   ;; 
+   ;;
    ;; -> (: erlang error (tuple 'error '"Buzz1/1 only accepts whole numbers > 0"))
    ;;
    ;; In this example it is enough we return the error atom.
@@ -116,5 +116,5 @@
   ;; type check that we have received a list as our second argument.
   ([acc (cons x xs)]
    ;; Place the result of our FizzBuzz at the start of the list and dive into
-   ;; the breach once more!   
+   ;; the breach once more!
    (tail-buzz (cons (get-fizz x) acc) xs)))

--- a/examples/gps1.lfe
+++ b/examples/gps1.lfe
@@ -21,8 +21,8 @@
 (defmodule gps1
   (export (gps 2) (gps 3) (school-ops 0))
   (import (from lists (member 2) (all 2) (any 2))
-	  ;; Rename lists functions to be more CL like.
-	  (rename lists ((all 2) every) ((any 2) some) ((filter 2) find-all))))
+      ;; Rename lists functions to be more CL like.
+      (rename lists ((all 2) every) ((any 2) some) ((filter 2) find-all))))
 
 ;; An operation.
 (defrecord op
@@ -31,22 +31,22 @@
 ;; General Problem Solver: achieve all goals using *ops*.
 (defun gps (state goals ops)
   ;; Set global variables
-  (defvar *state* state)	;The current state: a list of conditions.
-  (defvar *ops* ops)		;A list of available operators.
+  (defvar *state* state)    ;The current state: a list of conditions.
+  (defvar *ops* ops)        ;A list of available operators.
   (if (every (fun achieve 1) goals) 'solved))
 
 (defun gps (state goals)
   ;; Set global variables, but use existing *ops*
-  (defvar *state* state)	;The current state: a list of conditions.
+  (defvar *state* state)    ;The current state: a list of conditions.
   (if (every (fun achieve 1) goals) 'solved))
 
 ;; A goal is achieved if it already holds or if there is an
 ;; appropriate op for it that is applicable."
 (defun achieve (goal)
   (orelse (member goal (getvar *state*))
-	  (some (fun apply-op 1)
-		(find-all (lambda (op) (appropriate-p goal op))
-			  (getvar *ops*)))))
+      (some (fun apply-op 1)
+        (find-all (lambda (op) (appropriate-p goal op))
+              (getvar *ops*)))))
 
 ;; An op is appropriate to a goal if it is in its add list.
 (defun appropriate-p (goal op)
@@ -79,26 +79,26 @@
 (defun school-ops ()
   (list
     (make-op action 'drive-son-to-school
-	     preconds '(son-at-home car-works)
-	     add-list '(son-at-school)
-	     del-list '(son-at-home))
+         preconds '(son-at-home car-works)
+         add-list '(son-at-school)
+         del-list '(son-at-home))
     (make-op action 'shop-installs-battery
-	     preconds '(car-needs-battery shop-knows-problem shop-has-money)
-	     add-list '(car-works)
-	     del-list ())
+         preconds '(car-needs-battery shop-knows-problem shop-has-money)
+         add-list '(car-works)
+         del-list ())
     (make-op action 'tell-shop-problem
-	     preconds '(in-communication-with-shop)
-	     add-list '(shop-knows-problem)
-	     del-list ())
+         preconds '(in-communication-with-shop)
+         add-list '(shop-knows-problem)
+         del-list ())
     (make-op action 'telephone-shop
-	     preconds '(know-phone-number)
-	     add-list '(in-communication-with-shop)
-	     del-list ())
+         preconds '(know-phone-number)
+         add-list '(in-communication-with-shop)
+         del-list ())
     (make-op action 'look-up-number
-	     preconds '(have-phone-book)
-	     add-list '(know-phone-number)
-	     del-list ())
+         preconds '(have-phone-book)
+         add-list '(know-phone-number)
+         del-list ())
     (make-op action 'give-shop-money
-	     preconds '(have-money)
-	     add-list '(shop-has-money)
-	     del-list '(have-money))))
+         preconds '(have-money)
+         add-list '(shop-has-money)
+         del-list '(have-money))))

--- a/examples/http-sync.lfe
+++ b/examples/http-sync.lfe
@@ -57,8 +57,7 @@
   (export all))
 
 (defun parse-args (flag)
-  "
-  Given one or more command-line arguments, extract the passed values.
+  "Given one or more command-line arguments, extract the passed values.
 
   For example, if the following was passed via the command line:
 
@@ -70,31 +69,24 @@
       ...
       )
   In this example, the value assigned to the arg variable would be a list
-  containing the values my-value-1 and my-value-2.
-  "
+  containing the values my-value-1 and my-value-2."
   (let (((tuple 'ok data) (: init get_argument flag)))
     (: lists merge data)))
 
 (defun get-pages ()
-  "
-  With no argument, assume 'url parameter was passed via command line.
-  "
+  "With no argument, assume 'url parameter was passed via command line."
   (get-pages
     (parse-args 'url)))
 
 (defun get-pages (urls)
-  "
-  Start inets and make (potentially many) HTTP requests.
-  "
+  "Start inets and make (potentially many) HTTP requests."
   (: inets start)
   (: lists map
     (lambda (x)
       (get-page x)) urls))
 
 (defun get-page (url)
-  "
-  Make a single HTTP request.
-  "
+  "Make a single HTTP request."
   (case (: httpc request url)
     ((tuple 'ok result)
       (: io format '"Result: ~p~n" (list result)))

--- a/examples/internal-state.lfe
+++ b/examples/internal-state.lfe
@@ -84,22 +84,22 @@
 (defun send (object command arg)
   (funcall (get-method object command) arg))
 
-; returns an updated account object
 (defun withdraw (object amt)
+  "Returns an updated account object."
   (funcall (get-method object 'withdraw) amt))
 
-; returns an updated account object
 (defun deposit (object amt)
+  "Returns an updated account object."
   (funcall (get-method object 'deposit) amt))
 
-; returns a float representing the balance
 (defun balance (object)
+  "Returns a float representing the balance."
   (funcall (get-method object 'balance)))
 
-; returns a string represnting the account holder
 (defun name (object)
+  "Returns a string represnting the account holder."
   (funcall (get-method object 'name)))
 
-; returns an updated account object
 (defun interest (object)
+  "Returns an updated account object."
   (funcall (get-method object 'interest)))

--- a/examples/lfe_eval.lfe
+++ b/examples/lfe_eval.lfe
@@ -20,15 +20,15 @@
 
 (defmodule lfe_eval
   (export (expr 1) (expr 2) (gexpr 1) (gexpr 2) (apply 2) (apply 3)
-	  (make_letrec_env 2) (add_expr_func 4) (match 3))
+      (make_letrec_env 2) (add_expr_func 4) (match 3))
   ;; Deprecated exports.
   (export (eval 1) (eval 2) (eval_list 2))
   (import (from lfe_lib (new_env 0)
-		(add_vbinding 3) (add_vbindings 2) (get_vbinding 2)
-		(add_fbinding 4) (add_fbindings 2) (get_fbinding 3)
-		(add_ibinding 5) (get_gbinding 3))
-	  (from lists (reverse 1) (all 2) (map 2) (foldl 3) (foldr 3))
-	  (from orddict (find 2) (store 3)))
+        (add_vbinding 3) (add_vbindings 2) (get_vbinding 2)
+        (add_fbinding 4) (add_fbindings 2) (get_fbinding 3)
+        (add_ibinding 5) (get_gbinding 3))
+      (from lists (reverse 1) (all 2) (map 2) (foldl 3) (foldr 3))
+      (from orddict (find 2) (store 3)))
   (deprecated #(eval 1) #(eval 2)))
 
 (defun eval (e) (eval e (new_env)))
@@ -115,18 +115,18 @@
     ;; General function calls.
     ((cons fun es) (when (is_atom fun))
      ;; Note that macros have already been expanded here.
-     (let ((ar (length es)))		;Arity
+     (let ((ar (length es)))        ;Arity
        (case (get_fbinding fun ar env)
-	 ((tuple 'yes m f) (: erlang apply m f (eval-list es env)))
-	 ((tuple 'yes f) (eval-apply f (eval-list es env) env))
-	 ('no (: erlang error (tuple 'unbound_func (tuple fun ar)))))))
+     ((tuple 'yes m f) (: erlang apply m f (eval-list es env)))
+     ((tuple 'yes f) (eval-apply f (eval-list es env) env))
+     ('no (: erlang error (tuple 'unbound_func (tuple fun ar)))))))
     ((cons f es)
      (: erlang error (tuple 'bad_form 'application)))
     (e (if (is_atom e)
-	 (case (get_vbinding e env)
-	   ((tuple 'yes val) val)
-	   (no (: erlang error (tuple 'unbound_symb e))))
-	 e))))				;Atoms evaluate to themselves
+     (case (get_vbinding e env)
+       ((tuple 'yes val) val)
+       (no (: erlang error (tuple 'unbound_symb e))))
+     e))))                ;Atoms evaluate to themselves
 
 (defun eval-list (es env)
   (map (lambda (e) (eval-expr e env)) es))
@@ -155,20 +155,20 @@
 
 (defun parse-bitseg (f vsps env)
   (fletrec ((is-integer-list
-	     ([(cons i is)] (when (is_integer i)) (is-integer-list is))
-	     ([()] 'true)
-	     ([_] 'false)))
+         ([(cons i is)] (when (is_integer i)) (is-integer-list is))
+         ([()] 'true)
+         ([_] 'false)))
     ;; Test what structure the bitseg has.
-    (cond ((is-integer-list f)		;A string
-	   (let ((sp (parse-bitspecs () (make-spec) env)))
-	     (foldr (lambda (v vs) (cons (tuple v sp) vs)) vsps f)))
-	  ((?= (cons val specs) f)		;A value and spec
-	   (let ((sp (parse-bitspecs specs (make-spec) env)))
-	     (if (is-integer-list val)
-	       (foldr (lambda (v vs) (cons (tuple v sp) vs)) vsps val)
-	       (cons (tuple val sp) vsps))))
-	  (else				;A simple value
-	   (cons (tuple f (parse-bitspecs () (make-spec) env)) vsps)))))
+    (cond ((is-integer-list f)        ;A string
+       (let ((sp (parse-bitspecs () (make-spec) env)))
+         (foldr (lambda (v vs) (cons (tuple v sp) vs)) vsps f)))
+      ((?= (cons val specs) f)        ;A value and spec
+       (let ((sp (parse-bitspecs specs (make-spec) env)))
+         (if (is-integer-list val)
+           (foldr (lambda (v vs) (cons (tuple v sp) vs)) vsps val)
+           (cons (tuple val sp) vsps))))
+      (else                ;A simple value
+       (cons (tuple f (parse-bitspecs () (make-spec) env)) vsps)))))
 
 ;; (defun parse-bitseg (f env)
 ;;   (case f
@@ -177,10 +177,10 @@
 
 (defun eval-bitsegs (psps env)
   (foldl (lambda (psp acc)
-	    (let* (((tuple val spec) psp)
-		   (bin (eval-bitseg val spec env)))
-	      (binary (acc bitstring) (bin bitstring))))
-	 #b() psps))
+        (let* (((tuple val spec) psp)
+           (bin (eval-bitseg val spec env)))
+          (binary (acc bitstring) (bin bitstring))))
+     #b() psps))
 
 (defun eval-bitseg (val spec env)
   (let ((v (eval-expr val env)))
@@ -190,32 +190,32 @@
 
 (defun parse-bitspecs (ss spec0 env)
   (let* ((spec1 (foldl (lambda (s spec) (parse-bitspec s spec env)) spec0 ss))
-	 ((match-spec type ty size sz unit un sign si endian en) spec1))
+     ((match-spec type ty size sz unit un sign si endian en) spec1))
     ;; Adjust values depending on type and given value.
     (flet ((val-or-def (v def) (if (=:= v 'default) def v)))
       (case ty
-	('integer
-	 (tuple 'integer
-		(val-or-def sz 8) (val-or-def un 1)
-		(val-or-def si 'unsigned) (val-or-def en 'big)))
-	;; Ignore unused fields in utf types!
-	('utf8 (tuple 'utf8 'undefined 'undefined 'undefined 'undefined))
-	('utf16
-	 (tuple 'utf16 'undefined 'undefined 'undefined (val-or-def en 'big)))
-	('utf32
-	 (tuple 'utf32 'undefined 'undefined 'undefined (val-or-def en 'big)))
-	('float
-	 (tuple 'float
-		(val-or-def sz 64) (val-or-def un 1)
-		(val-or-def si 'unsigned) (val-or-def en 'big)))
-	('binary
-	 (tuple 'binary
-		(val-or-def sz 'all) (val-or-def un 8)
-		(val-or-def si 'unsigned) (val-or-def en 'big)))
-	('bitstring
-	 (tuple 'binary
-		(val-or-def sz 'all) (val-or-def un 1)
-		(val-or-def si 'unsigned) (val-or-def en 'big)))))))
+    ('integer
+     (tuple 'integer
+        (val-or-def sz 8) (val-or-def un 1)
+        (val-or-def si 'unsigned) (val-or-def en 'big)))
+    ;; Ignore unused fields in utf types!
+    ('utf8 (tuple 'utf8 'undefined 'undefined 'undefined 'undefined))
+    ('utf16
+     (tuple 'utf16 'undefined 'undefined 'undefined (val-or-def en 'big)))
+    ('utf32
+     (tuple 'utf32 'undefined 'undefined 'undefined (val-or-def en 'big)))
+    ('float
+     (tuple 'float
+        (val-or-def sz 64) (val-or-def un 1)
+        (val-or-def si 'unsigned) (val-or-def en 'big)))
+    ('binary
+     (tuple 'binary
+        (val-or-def sz 'all) (val-or-def un 8)
+        (val-or-def si 'unsigned) (val-or-def en 'big)))
+    ('bitstring
+     (tuple 'binary
+        (val-or-def sz 'all) (val-or-def un 1)
+        (val-or-def si 'unsigned) (val-or-def en 'big)))))))
 
 (defun parse-bitspec (spec sp env)
   (case spec
@@ -265,7 +265,7 @@
     ((tuple 'binary 'all un _ _)
      (case (bit_size val)
        (size (when (=:= (rem size un) 0))
-	     (binary (val bitstring (size size))))
+         (binary (val bitstring (size size))))
        (_ (: erlang error 'bad_arg))))
     ((tuple 'binary sz un _ _)
      (binary (val bitstring (size (* sz un)))))))
@@ -309,34 +309,34 @@
      (4 (lambda (a b c d) (apply-lambda args body (list a b c d) env)))
      (5 (lambda (a b c d e) (apply-lambda args body (list a b c d e) env)))
      (6 (lambda (a b c d e f)
-	  (apply-lambda args body (list a b c d e f) env)))
+      (apply-lambda args body (list a b c d e f) env)))
      (7 (lambda (a b c d e f g)
-	  (apply-lambda args body (list a b c d e f g) env)))
+      (apply-lambda args body (list a b c d e f g) env)))
      (8 (lambda (a b c d e f g h)
-	  (apply-lambda args body (list a b c d e f g h) env)))
+      (apply-lambda args body (list a b c d e f g h) env)))
      (9 (lambda (a b c d e f g h i)
-	  (apply-lambda args body (list a b c d e f g h i) env)))
+      (apply-lambda args body (list a b c d e f g h i) env)))
      (10 (lambda (a b c d e f g h i j)
-	   (apply-lambda args body (list a b c d e f g h i j) env)))
+       (apply-lambda args body (list a b c d e f g h i j) env)))
      (11 (lambda (a b c d e f g h i j k)
-	   (apply-lambda args body (list a b c d e f g h i j k) env)))
+       (apply-lambda args body (list a b c d e f g h i j k) env)))
      (12 (lambda (a b c d e f g h i j k l)
-	   (apply-lambda args body (list a b c d e f g h i j k l) env)))
+       (apply-lambda args body (list a b c d e f g h i j k l) env)))
      (13 (lambda (a b c d e f g h i j k l m)
-	   (apply-lambda args body (list a b c d e f g h i j k l m) env)))
+       (apply-lambda args body (list a b c d e f g h i j k l m) env)))
      (14 (lambda (a b c d e f g h i j k l m n)
-	   (apply-lambda args body (list a b c d e f g h i j k l m n) env)))
+       (apply-lambda args body (list a b c d e f g h i j k l m n) env)))
      (15 (lambda (a b c d e f g h i j k l m n o)
-	   (apply-lambda args body (list a b c d e f g h i j k l m n o) env)))
+       (apply-lambda args body (list a b c d e f g h i j k l m n o) env)))
      )))
 
 (defun apply-lambda (args body vals env)
   (fletrec ((bind-args
-	     ([(cons '_ as) (cons _ es) env]	;Ignore don't care variables
-	      (bind-args as es env))
-	     ([(cons a as) (cons e es) env] (when (is_atom a))
-	      (bind-args as es (add_vbinding a e env)))
-	     ([() () env] env)))
+         ([(cons '_ as) (cons _ es) env]    ;Ignore don't care variables
+          (bind-args as es env))
+         ([(cons a as) (cons e es) env] (when (is_atom a))
+          (bind-args as es (add_vbinding a e env)))
+         ([() () env] env)))
     (eval-body body (bind-args args vals env))))
 
 ;; eval-match-lambda (MatchClauses Env) -> Value
@@ -352,25 +352,25 @@
     (4 (lambda (a b c d) (apply-match-clauses cls (list a b c d) env)))
     (5 (lambda (a b c d e) (apply-match-clauses cls (list a b c d e) env)))
     (6 (lambda (a b c d e f)
-	  (apply-match-clauses cls (list a b c d e f) env)))
+      (apply-match-clauses cls (list a b c d e f) env)))
     (7 (lambda (a b c d e f g)
-	  (apply-match-clauses cls (list a b c d e f g) env)))
+      (apply-match-clauses cls (list a b c d e f g) env)))
     (8 (lambda (a b c d e f g h)
-	  (apply-match-clauses cls (list a b c d e f g h) env)))
+      (apply-match-clauses cls (list a b c d e f g h) env)))
     (9 (lambda (a b c d e f g h i)
-	  (apply-match-clauses cls (list a b c d e f g h i) env)))
+      (apply-match-clauses cls (list a b c d e f g h i) env)))
     (10 (lambda (a b c d e f g h i j)
-	  (apply-match-clauses cls (list a b c d e f g h i j) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j) env)))
     (11 (lambda (a b c d e f g h i j k)
-	  (apply-match-clauses cls (list a b c d e f g h i j k) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j k) env)))
     (12 (lambda (a b c d e f g h i j k l)
-	  (apply-match-clauses cls (list a b c d e f g h i j k l) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j k l) env)))
     (13 (lambda (a b c d e f g h i j k l m)
-	  (apply-match-clauses cls (list a b c d e f g h i j k l m) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j k l m) env)))
     (14 (lambda (a b c d e f g h i j k l m n)
-	  (apply-match-clauses cls (list a b c d e f g h i j k l m n) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j k l m n) env)))
     (15 (lambda (a b c d e f g h i j k l m n o)
-	  (apply-match-clauses cls (list a b c d e f g h i j k l m n o) env)))
+      (apply-match-clauses cls (list a b c d e f g h i j k l m n o) env)))
     ))
 
 (defun match-lambda-arity (cls) (length (caar cls)))
@@ -383,44 +383,44 @@
        ;; and pass in as one pattern. Have already checked a
        ;; proper list.
        (case (match-when (cons 'list pats) as body env)
-	 ((tuple 'yes body1 vbs) (eval-body body1 (add_vbindings vbs env)))
-	 ('no (apply-match-clauses cls as env)))
+     ((tuple 'yes body1 vbs) (eval-body body1 (add_vbindings vbs env)))
+     ('no (apply-match-clauses cls as env)))
        (: erlang error 'badarity)))
     (_ (: erlang error 'function_clause))))
 
 ;; (eval-let (PatBindings . Body) Env) -> Value.
 
 (defun eval-let (body env0)
-  (let* (((cons vbs b) body)		;Must match this
-	 ;; Make sure we use the right environment.
-	 (env (foldl (match-lambda
-		       ([(list pat e) env]
-			(let ((val (eval-expr e env0)))
-			  (case (match pat val env0)
-			    ((tuple 'yes bs) (add_vbindings bs env))
-			    ('no (: erlang error (tuple 'badmatch val))))))
-		       ([(list pat (= (cons 'when _) g) e) env]
-			(let ((val (eval-expr e env0)))
-			  (case (match-when pat val (list g) env0)
-			    ((tuple 'yes '() bs) (add_vbindings bs env))
-			    ('no (: erlang error (tuple 'badmatch val))))))
-		       ([_ _] (: erlang error (tuple 'bad_form 'let))))
-		     env0 vbs)))
+  (let* (((cons vbs b) body)        ;Must match this
+     ;; Make sure we use the right environment.
+     (env (foldl (match-lambda
+               ([(list pat e) env]
+            (let ((val (eval-expr e env0)))
+              (case (match pat val env0)
+                ((tuple 'yes bs) (add_vbindings bs env))
+                ('no (: erlang error (tuple 'badmatch val))))))
+               ([(list pat (= (cons 'when _) g) e) env]
+            (let ((val (eval-expr e env0)))
+              (case (match-when pat val (list g) env0)
+                ((tuple 'yes '() bs) (add_vbindings bs env))
+                ('no (: erlang error (tuple 'badmatch val))))))
+               ([_ _] (: erlang error (tuple 'bad_form 'let))))
+             env0 vbs)))
     (eval-body b env)))
 
 ;; (eval-let-function (FuncBindings . Body) Env) -> Value.
 
 (defun eval-let-function (form env0)
   (let* (((cons fbs body) form)
-	 (env (foldl (match-lambda
-		       ([(list v (= (list* 'lambda as _) f)) e]
-			(when (is_atom v))
-			(add_fbinding v (length as) (tuple 'expr f env0) e))
-		       ([(list v (= (list* 'match-lambda (cons pats _) _) f)) e]
-			(when (is_atom v))
-			(add_fbinding v (length pats) (tuple 'expr f env0) e))
-		       ([_ _] (: erlang error (tuple 'bad_form 'let-function))))
-		     env0 fbs)))
+     (env (foldl (match-lambda
+               ([(list v (= (list* 'lambda as _) f)) e]
+            (when (is_atom v))
+            (add_fbinding v (length as) (tuple 'expr f env0) e))
+               ([(list v (= (list* 'match-lambda (cons pats _) _) f)) e]
+            (when (is_atom v))
+            (add_fbinding v (length pats) (tuple 'expr f env0) e))
+               ([_ _] (: erlang error (tuple 'bad_form 'let-function))))
+             env0 fbs)))
     (eval-body body env)))
 
 ;; (eval-letrec-function (FuncBindings . Body) Env) -> Value.
@@ -429,16 +429,16 @@
 
 (defun eval-letrec-function (form env0)
   (let* (((cons fbs0 body) form)
-	 (fbs1 (map (match-lambda
-		      ([(list v (= (list* 'lambda args body) f))]
-		       (when (is_atom v))
-		       (tuple v (length args) f))
-		      ([(list v (= (list* 'match-lambda (cons pats _) _) f))]
-		       (when (is_atom v))
-		       (tuple v (length pats) f))
-		      ([_] (: erlang error (tuple 'bad_form 'letrec-function))))
-		    fbs0))
-	 (env1 (make_letrec_env fbs1 env0)))
+     (fbs1 (map (match-lambda
+              ([(list v (= (list* 'lambda args body) f))]
+               (when (is_atom v))
+               (tuple v (length args) f))
+              ([(list v (= (list* 'match-lambda (cons pats _) _) f))]
+               (when (is_atom v))
+               (tuple v (length pats) f))
+              ([_] (: erlang error (tuple 'bad_form 'letrec-function))))
+            fbs0))
+     (env1 (make_letrec_env fbs1 env0)))
     (eval-body body env1)))
 
 ;; (make_letrec_env fbs env) -> env.
@@ -455,9 +455,9 @@
 
 (defun make_letrec_env (fbs0 env)
   (let ((fbs (map (lambda (fb)
-		    (let (((tuple v ar body) fb))
-		      (tuple v ar (tuple 'letrec body fbs0 env))))
-		  fbs0)))
+            (let (((tuple v ar body) fb))
+              (tuple v ar (tuple 'letrec body fbs0 env))))
+          fbs0)))
     (add_fbindings fbs env)))
 
 (defun extend_letrec_env (lete0 fbs0 env0)
@@ -484,21 +484,21 @@
     ((tuple 'letrec body fbs env)
      ;; A function created by/for letrec-function.
      (let ((newenv (foldl (match-lambda
-			    ([(tuple v ar lambda) e]
-			     (add_fbinding v ar
-					   (tuple 'letrec lambda fbs env) e)))
-			  env fbs)))
+                ([(tuple v ar lambda) e]
+                 (add_fbinding v ar
+                       (tuple 'letrec lambda fbs env) e)))
+              env fbs)))
        (eval-apply (tuple 'expr body newenv) es env0)))))
 
 ;; (eval-if body env) -> value
 
 (defun eval-if (body env)
   (flet ((eval-if (test true false)
-		  ;; Use explicit case to catch errors.
-		  (case (eval-expr test env)
-		    ('true (eval-expr true env))
-		    ('false (eval-expr false env))
-		    (_ (: erlang error 'if_clause)))))
+          ;; Use explicit case to catch errors.
+          (case (eval-expr test env)
+            ('true (eval-expr true env))
+            ('false (eval-expr false env))
+            (_ (: erlang error 'if_clause)))))
     (case body
       ((list test true) (eval-if test true 'false))
       ((list test true false) (eval-if test true false)))))
@@ -507,7 +507,7 @@
 
 (defun eval-case (body env)
   (eval-case-clauses (eval-expr (car body) env)
-		     (cdr body) env))
+             (cdr body) env))
 
 (defun eval-case-clauses (v cls env)
   (case (match-clause v cls env)
@@ -527,16 +527,16 @@
 
 (defun eval-receive (body env)
   (fletrec ((split-rec
-	     ([(list (list* 'after t b)) rcls]
-	      (tuple (reverse rcls) t b))
-	     ([(cons cl b) rcls]
-	      (split-rec b (cons cl rcls)))
-	     ([() rcls]			;No timeout, return 'infinity
-	      (tuple (reverse rcls) 'infinity ()))))
+         ([(list (list* 'after t b)) rcls]
+          (tuple (reverse rcls) t b))
+         ([(cons cl b) rcls]
+          (split-rec b (cons cl rcls)))
+         ([() rcls]            ;No timeout, return 'infinity
+          (tuple (reverse rcls) 'infinity ()))))
     (let (((tuple cls te tb) (split-rec body [])))
       (case (eval-expr te env)
-	('infinity (receive-clauses cls env))
-	(t (receive-clauses t tb cls env))))))
+    ('infinity (receive-clauses cls env))
+    (t (receive-clauses t tb cls env))))))
 
 ;; (receive-clauses Clauses Env) -> Value.
 ;;  Recurse down message queue. We are only called with timeout value
@@ -544,13 +544,13 @@
 
 (defun receive-clauses (cls env)
   (fletrec ((rec-clauses
-	     (ms)
-	     (receive
-	      (msg (case (match-clause msg cls env)
-		     ((tuple 'yes b vbs)
-		      (merge-queue ms)
-		      (eval-body b (add_vbindings vbs env)))
-		     ('no (rec-clauses (cons msg ms))))))))
+         (ms)
+         (receive
+          (msg (case (match-clause msg cls env)
+             ((tuple 'yes b vbs)
+              (merge-queue ms)
+              (eval-body b (add_vbindings vbs env)))
+             ('no (rec-clauses (cons msg ms))))))))
     (rec-clauses ())))
 
 ;; (receive-clauses Timeout TimeoutBody Clauses Env) -> Value.
@@ -560,21 +560,21 @@
 
 (defun receive-clauses (t tb cls env)
   (fletrec ((rec-clauses
-	     (t ms)
-	     (receive
-	       (msg
-		(case (match-clause msg cls env)
-		  ((tuple 'yes b vbs)
-		   (merge-queue ms)
-		   (eval-body b (add_vbindings vbs env)))
-		  ('no
-		   (let (((tuple _ t1) (statistics 'runtime)))
-		     (if (< t t1)
-		       (rec-clauses 0 (cons msg ms))
-		       (rec-clauses (- t t1) (cons msg ms)))))))
-	       (after t
-		 (merge-queue ms)
-		 (eval-body tb env)))))
+         (t ms)
+         (receive
+           (msg
+        (case (match-clause msg cls env)
+          ((tuple 'yes b vbs)
+           (merge-queue ms)
+           (eval-body b (add_vbindings vbs env)))
+          ('no
+           (let (((tuple _ t1) (statistics 'runtime)))
+             (if (< t t1)
+               (rec-clauses 0 (cons msg ms))
+               (rec-clauses (- t t1) (cons msg ms)))))))
+           (after t
+         (merge-queue ms)
+         (eval-body tb env)))))
     (statistics 'runtime)
     (rec-clauses t [])))
 
@@ -583,17 +583,17 @@
 ;; the messages in the queue then sending them all back to ourselves.
 
 (defun merge-queue (ms)
-  (fletrec ((recv-all (ms)		;Receive all remaining messages
-		      (receive
-			(msg (recv-all (cons msg ms)))
-			(after 0
-			  (reverse ms))))
-	    (send-all (ms self)		;Send them all back to ourselves
-		      (case ms
-			((cons m ms)
-			 (! self m)
-			 (send-all ms self))
-			(() 'ok))))
+  (fletrec ((recv-all (ms)        ;Receive all remaining messages
+              (receive
+            (msg (recv-all (cons msg ms)))
+            (after 0
+              (reverse ms))))
+        (send-all (ms self)        ;Send them all back to ourselves
+              (case ms
+            ((cons m ms)
+             (! self m)
+             (send-all ms self))
+            (() 'ok))))
     (send-all (recv-all ms) (self))))
 
 ;; (eval-try body env) -> value
@@ -619,20 +619,20 @@
   (try
       (eval-expr e env)
     (case
-	(r (case case
-	     ((list cls) (eval-case-clauses r cls env))
-	     (() r))))
+    (r (case case
+         ((list cls) (eval-case-clauses r cls env))
+         (() r))))
     (catch
       ((tuple class error _)
        ;; Get stack trace explicitly.
        (let ((stk (: erlang get_stacktrace)))
-	 (case catch
-	   ((list cls) (eval-catch-clauses (tuple class error stk) cls env))
-	   (() (: erlang raise class error stk))))))
+     (case catch
+       ((list cls) (eval-catch-clauses (tuple class error stk) cls env))
+       (() (: erlang raise class error stk))))))
     (after
-	(case after
-	  ((list b) (eval-body b env))
-	  (() ())))))
+    (case after
+      ((list b) (eval-body b env))
+      (() ())))))
 
 (defun eval-catch-clauses
   ([v (cons (cons pat b) cls) env]
@@ -646,8 +646,8 @@
   (case b
     ((list* m f as)
      (let ((m (eval-expr m env))
-	   (f (eval-expr f env))
-	   (as (eval-list as env)))
+       (f (eval-expr f env))
+       (as (eval-list as env)))
        (: erlang apply m f as)))))
 
 ;; (match-when pattern value body env) -> #('yes restbody bindings) | 'no.
@@ -658,9 +658,9 @@
     ((tuple 'yes vbs)
      (case b0
        ((cons (cons 'when g) b1)
-	(if (eval-guard g (add_vbindings vbs env))
-	  (tuple 'yes b1 vbs)
-	  'no))
+    (if (eval-guard g (add_vbindings vbs env))
+      (tuple 'yes b1 vbs)
+      'no))
        (b1 (tuple 'yes b1 vbs))))
     ('no 'no)))
 
@@ -671,9 +671,9 @@
   (try
       (eval-gbody gts env)
     (case ('true 'true)
-      (_ 'false))			;Fail guard
+      (_ 'false))            ;Fail guard
     (catch
-      ((tuple t v i) 'false))))		;Fail guard
+      ((tuple t v i) 'false))))        ;Fail guard
 
 ;; (eval-gbody body env) -> true | false.
 ;; A body is a sequence of tests which must all succeed.
@@ -703,22 +703,22 @@
     ((cons 'if b) (eval-gif b env))
     ((list* 'call 'erlang f as)
      (let ((f (eval-gexpr f env))
-	   (ar (length as)))
+       (ar (length as)))
        (case (get_gbinding f ar env)
-	 ((tuple 'yes m f) (: erlang apply m f (eval-glist as env)))
-	 (_ (: erlang error (tuple 'unbound_func (tuple f (length as))))))))
+     ((tuple 'yes m f) (: erlang apply m f (eval-glist as env)))
+     (_ (: erlang error (tuple 'unbound_func (tuple f (length as))))))))
     ((cons f as) (when (is_atom f))
      (let ((ar (length as)))
        (case (get_gbinding f ar env)
-	 ((tuple 'yes m f) (: erlang apply m f (eval-glist as env)))
-	 ('no (: erlang error (tuple 'unbound_func (tuple f ar)))))))
-    ((cons f es)			;Everything else not allowed
+     ((tuple 'yes m f) (: erlang apply m f (eval-glist as env)))
+     ('no (: erlang error (tuple 'unbound_func (tuple f ar)))))))
+    ((cons f es)            ;Everything else not allowed
      (: erlang error 'illegal_guard))
     (e (if (is_atom e)
-	 (case (get_vbinding e env)
-	   ((tuple 'yes val) val)
-	   (no (: erlang error (tuple 'unbound_symb e))))
-	 e))))				;Atoms evaluate to themselves
+     (case (get_vbinding e env)
+       ((tuple 'yes val) val)
+       (no (: erlang error (tuple 'unbound_symb e))))
+     e))))                ;Atoms evaluate to themselves
 
 (defun eval-glist (es env)
   (map (lambda (e) (eval-gexpr e env)) es))
@@ -732,10 +732,10 @@
 
 (defun eval-gbitsegs (psps env)
   (foldl (lambda (psp acc)
-	    (let* (((tuple val spec) psp)
-		   (bin (eval-gbitseg val spec env)))
-	      (binary (acc bitstring) (bin bitstring))))
-	 #b() psps))
+        (let* (((tuple val spec) psp)
+           (bin (eval-gbitseg val spec env)))
+          (binary (acc bitstring) (bin bitstring))))
+     #b() psps))
 
 (defun eval-gbitseg (val spec env)
   (let ((v (eval-gexpr val env)))
@@ -745,9 +745,9 @@
 
 (defun eval-gif (body env)
   (flet ((eval-gif (test true false)
-		   (if (eval-gexpr test env)
-		     (eval-gexpr true env)
-		     (eval-gexpr false env))))
+           (if (eval-gexpr test env)
+             (eval-gexpr true env)
+             (eval-gexpr false env))))
     (case body
       ((list test true) (eval-gif test true 'false))
       ((list test true false) (eval-gif test true false)))))
@@ -769,7 +769,7 @@
    (if (is_bitstring val)
      (match-binary fs val env bs)
      'no))
-  ([(list '= p1 p2) val env bs]		;Aliases
+  ([(list '= p1 p2) val env bs]        ;Aliases
    (case (match p1 val env bs)
      ((tuple 'yes bs) (match p2 val env bs))
      ('no 'no)))
@@ -777,14 +777,14 @@
    (case (match p v env bs)
      ((tuple 'yes bs) (match ps vs env bs))
      ('no 'no)))
-  ([(cons 'list ps) val env bs]		;Explicit list constructor
+  ([(cons 'list ps) val env bs]        ;Explicit list constructor
    (match-list ps val env bs))
   ;; Use old no contructor list forms.
   ([(cons p ps) (cons v vs) env bs]
    (case (match p v env bs)
      ((tuple 'yes bs) (match ps vs env bs))
      ('no 'no)))
-;;  ([(cons _ _) _ _ _] 'no)		;No constructor
+;;  ([(cons _ _) _ _ _] 'no)        ;No constructor
 
   ([() () env bs] (tuple 'yes bs))
   ([symb val env bs] (when (is_atom symb))
@@ -801,11 +801,11 @@
   ([_ _ _ _] 'no))
 
 (defun match-symb (symb val env bs)
-  (if (== symb '_) (tuple 'yes bs)	;Don't care variable
+  (if (== symb '_) (tuple 'yes bs)    ;Don't care variable
       ;; Check if symbol already bound.
       (case (find symb bs)
-	((tuple 'ok _) 'no)		;Already bound, multiple variable
-	('error (tuple 'yes (store symb val bs))))))
+    ((tuple 'ok _) 'no)        ;Already bound, multiple variable
+    ('error (tuple 'yes (store symb val bs))))))
 
 ;; (match-binary bitsegs binary env bindings) -> (tuple 'yes bindings) | 'no.
 ;;  Match Bitsegs against Binary. This code is taken from
@@ -815,18 +815,18 @@
 (defun match-binary (fs bin env bs)
   (let ((psps (parse-bitsegs fs env)))
     (case (catch (match-bitsegs psps bin env bs))
-      ((tuple 'yes bs) (tuple 'yes bs))	;Matched whole binary
-      ((tuple 'EXIT _) 'no))))		;Error is no match
+      ((tuple 'yes bs) (tuple 'yes bs))    ;Matched whole binary
+      ((tuple 'EXIT _) 'no))))        ;Error is no match
 
 (defun match-bitsegs
   ([(cons (tuple pat specs) psps) bin0 env bs0]
    (let (((tuple 'yes bin1 bs1) (match-bitseg pat specs bin0 env bs0)))
      (match-bitsegs psps bin1 env bs1)))
-  ([() #b() _ bs] (tuple 'yes bs)))	;Reached the end of both
+  ([() #b() _ bs] (tuple 'yes bs)))    ;Reached the end of both
 
 (defun match-bitseg (pat spec bin0 env bs0)
   (let* (((tuple val bin1) (get-pat-bitseg bin0 spec))
-	 ((tuple 'yes bs1) (match pat val env bs0)))
+     ((tuple 'yes bs1) (match pat val env bs0)))
     (tuple 'yes bin1 bs1)))
 
 ;; (get-pat-bitseg binary #(type size unit sign endian)) -> #(value restbinary)
@@ -847,33 +847,33 @@
        (tuple bin #b())))
     ((tuple 'binary sz un _ _)
      (let* ((tot-size (* sz un))
-	    ((binary (val bitstring (size tot-size)) (rest bitstring)) bin))
+        ((binary (val bitstring (size tot-size)) (rest bitstring)) bin))
        (tuple val rest)))))
 
 (defun get-int-bitseg
   ([bin sz 'signed 'big]
    (let (((binary (val signed big-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest)))
   ([bin sz 'unsigned 'big]
    (let (((binary (val unsigned big-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest)))
   ([bin sz 'signed 'little]
    (let (((binary (val signed little-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest)))
   ([bin sz 'unsigned 'little]
    (let (((binary (val unsigned little-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest)))
   ([bin sz 'signed 'native]
    (let (((binary (val signed native-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest)))
   ([bin sz 'unsigned 'native]
    (let (((binary (val unsigned native-endian (size sz))
-		  (rest bitstring)) bin))
+          (rest bitstring)) bin))
      (tuple val rest))))
 
 (defun get-utf-8-bitseg (bin)
@@ -883,20 +883,20 @@
 (defun get-utf-16-bitseg (bin en)
   (case en
     ('big (let (((binary (val utf-16 big-endian) (rest bitstring)) bin))
-	    (tuple val rest)))
+        (tuple val rest)))
     ('little (let (((binary (val utf-16 little-endian) (rest bitstring)) bin))
-	       (tuple val rest)))
+           (tuple val rest)))
     ('native (let (((binary (val utf-16 native-endian) (rest bitstring)) bin))
-	       (tuple val rest)))))
+           (tuple val rest)))))
 
 (defun get-utf-32-bitseg (bin en)
   (case en
     ('big (let (((binary (val utf-32 big-endian) (rest bitstring)) bin))
-	    (tuple val rest)))
+        (tuple val rest)))
     ('little (let (((binary (val utf-32 little-endian) (rest bitstring)) bin))
-	       (tuple val rest)))
+           (tuple val rest)))
     ('native (let (((binary (val utf-32 native-endian) (rest bitstring)) bin))
-	       (tuple val rest)))))
+           (tuple val rest)))))
 
 (defun get-float-bitseg (bin sz en)
   (case en

--- a/examples/mnesia_demo.lfe
+++ b/examples/mnesia_demo.lfe
@@ -32,32 +32,32 @@
   (: mnesia create_table 'person '(#(attributes (name place job))))
   ;; Initialise the table.
   (let ((people '(
-		  ;; First some people in London.
-		  #(fred london waiter)
-		  #(bert london waiter)
-		  #(john london painter)
-		  #(paul london driver)
-		  ;; Now some in Paris.
-		  #(jean paris waiter)
-		  #(gerard paris driver)
-		  #(claude paris painter)
-		  #(yves paris waiter)
-		  ;; And some in Rome.
-		  #(roberto rome waiter)
-		  #(guiseppe rome driver)
-		  #(paulo rome painter)
-		  ;; And some in Berlin.
-		  #(fritz berlin painter)
-		  #(kurt berlin driver)
-		  #(hans berlin waiter)
-		  #(franz berlin waiter)
-		  )))
+          ;; First some people in London.
+          #(fred london waiter)
+          #(bert london waiter)
+          #(john london painter)
+          #(paul london driver)
+          ;; Now some in Paris.
+          #(jean paris waiter)
+          #(gerard paris driver)
+          #(claude paris painter)
+          #(yves paris waiter)
+          ;; And some in Rome.
+          #(roberto rome waiter)
+          #(guiseppe rome driver)
+          #(paulo rome painter)
+          ;; And some in Berlin.
+          #(fritz berlin painter)
+          #(kurt berlin driver)
+          #(hans berlin waiter)
+          #(franz berlin waiter)
+          )))
     (: lists foreach (match-lambda
-		       ([(tuple n p j)]
-			(: mnesia transaction
-			  (lambda ()
-			    (let ((new (make-person name n place p job j)))
-			      (: mnesia write new))))))
+               ([(tuple n p j)]
+            (: mnesia transaction
+              (lambda ()
+                (let ((new (make-person name n place p job j)))
+                  (: mnesia write new))))))
        people)))
 
 ;; Match records by place using match_object and the emp-XXXX macro.
@@ -68,18 +68,18 @@
 ;; Use match specifications to match records
 (defun by_place_ms (place)
   (let ((f (lambda () (: mnesia select 'person
-			 (match-spec ([(match-person name n place p job j)]
-				      (when (=:= p place))
-				      (tuple n j)))))))
+             (match-spec ([(match-person name n place p job j)]
+                      (when (=:= p place))
+                      (tuple n j)))))))
     (: mnesia transaction f)))
 
 ;; Use Query List Comprehensions to match records
 (defun by_place_qlc (place)
   (let ((f (lambda ()
-	     (let ((q (qlc (lc ((<- person (: mnesia table 'person))
-				(=:= (person-place person) place))
-			     person))))
-	       (: qlc e q)))))
+         (let ((q (qlc (lc ((<- person (: mnesia table 'person))
+                (=:= (person-place person) place))
+                 person))))
+           (: qlc e q)))))
     (: mnesia transaction f)))
 
 ;; Ignore this

--- a/examples/object-via-closure.lfe
+++ b/examples/object-via-closure.lfe
@@ -79,22 +79,18 @@
  (export all))
 
 (defun fish-class (species)
-  "
-  This is the constructor that will be used most often, only requiring that
+  "This is the constructor that will be used most often, only requiring that
   one pass a 'species' string.
 
-  When the children are not defined, simply use an empty list.
-  "
+  When the children are not defined, simply use an empty list."
   (fish-class species ()))
 
 (defun fish-class (species children)
-  "
-  This contructor is mostly useful as a way of abstracting out the id
+  "This contructor is mostly useful as a way of abstracting out the id
   generation from the larger constructor. Nothing else uses fish-class/2
   besides fish-class/1, so it's not strictly necessary.
 
-  When the id isn't known, generate one.
-  "
+  When the id isn't known, generate one."
   (let* (((binary (id (size 128))) (: crypto rand_bytes 16))
          (formatted-id (car
                          (: io_lib format
@@ -102,10 +98,8 @@
     (fish-class species children formatted-id)))
 
 (defun fish-class (species children id)
-  "
-  This is the constructor used internally, once the children and fish id are
-  known.
-  "
+  "This is the constructor used internally, once the children and fish id are
+  known."
   (let ((move-verb '"swam"))
     (lambda (method-name)
       (case method-name
@@ -141,14 +135,12 @@
             (: erlang length children)))))))
 
 (defun get-method (object method-name)
-  "
-  This is a generic function, used to call into the given object (class
-  instance).
-  "
+  "This is a generic function, used to call into the given object (class
+  instance)."
   (funcall object method-name))
 
-; define object methods
 (defun get-id (object)
+  "Define object methods."
   (funcall (get-method object 'id) object))
 
 (defun get-species (object)

--- a/examples/object-via-process.lfe
+++ b/examples/object-via-process.lfe
@@ -79,21 +79,17 @@
  (export all))
 
 (defun fish-class (species)
-  "
-  This is the constructor that will be used most often, only requiring that
+  "This is the constructor that will be used most often, only requiring that
   one pass a 'species' string.
 
-  When the children are not defined, simply use an empty list.
-  "
+  When the children are not defined, simply use an empty list."
   (fish-class species ()))
 
 (defun fish-class (species children)
-  "
-  This constructor is useful for two reasons:
+  "This constructor is useful for two reasons:
     1) as a way of abstracting out the id generation from the
        larger constructor, and
-    2) spawning the 'object loop' code (fish-class/3).
-  "
+    2) spawning the 'object loop' code (fish-class/3)."
   (let* (((binary (id (size 128))) (: crypto rand_bytes 16))
          (formatted-id (car
                          (: io_lib format
@@ -103,11 +99,9 @@
            (list species children formatted-id))))
 
 (defun fish-class (species children id)
-  "
-  This function is intended to be spawned as a separate process which is
+  "This function is intended to be spawned as a separate process which is
   used to track the state of a fish. In particular, fish-class/2 spawns
-  this function (which acts as a loop, pattern matching for messages).
-  "
+  this function (which acts as a loop, pattern matching for messages)."
   (let ((move-verb '"swam"))
     (receive
       ((tuple caller 'move distance)
@@ -137,24 +131,20 @@
         (fish-class species children-ids id))))))
 
 (defun call-method (object method-name)
-  "
-  This is a generic function, used to call into the given object (class
-  instance).
-  "
+  "This is a generic function, used to call into the given object (class
+  instance)."
   (! object (tuple (self) method-name))
   (receive
     (data data)))
 
 (defun call-method (object method-name arg)
-  "
-  Same as above, but with an additional argument.
-  "
+  "Same as above, but with an additional argument."
   (! object (tuple (self) method-name arg))
   (receive
     (data data)))
 
-; define object methods
 (defun get-id (object)
+  "Define object methods."
   (call-method object 'id))
 
 (defun get-species (object)

--- a/examples/ping_pong.lfe
+++ b/examples/ping_pong.lfe
@@ -22,7 +22,7 @@
   (export (start_link 0) (ping 0))
   (export (init 1) (handle_call 3) (handle_cast 2)
           (handle_info 2) (terminate 2) (code_change 3))
-  (behaviour gen_server))		;Just indicates intent
+  (behaviour gen_server))        ;Just indicates intent
 
 (defun start_link ()
   (: gen_server start_link

--- a/examples/sample-lfescript
+++ b/examples/sample-lfescript
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; File    : sample-lfescript.lfe
+;; File    : sample-lfescript
 ;; Author  : Robert Virding and Duncan McGreggor
 ;; Purpose : Demonstrating usage of lfescript
 
@@ -24,17 +24,17 @@
 ;;  1) make sure that you are in your lfe working directory
 ;;  2) $ export PATH=$PATH:./bin
 ;;  3) $ export LFESCRIPT_EMULATOR="erl -pa ./ebin"
-;;  4) $ chmod 755 examples/sample-lfescript.lfe
+;;  4) $ chmod 755 examples/sample-lfescript
 ;;
 ;; At this point, you can call this script directly:
 ;;
 ;;  $ examples/sample-lfescript.lfe
-;;  usage: examples/sample-lfescript.lfe <integer>
+;;  usage: examples/sample-lfescript <integer>
 ;;
 ;; As you can see, calling the script like that displays the usage statement.
 ;; Now call the script as intended, like the usage says:
 ;;
-;;  $ examples/sample-lfescript.lfe 12
+;;  $ examples/sample-lfescript 12
 ;;  factorial 12 = 479001600
 ;;
 ;; For more information, see ./doc/lfescript.txt.

--- a/examples/simple-erl-exercises.lfe
+++ b/examples/simple-erl-exercises.lfe
@@ -138,7 +138,8 @@
 
 (defun start_ring (n-rings n-msgs)
   ;; Create the desired number of "servers" in the ring.
-  (let [((cons x xs) (create-pids-one-arg 'ring n-msgs (: lists seq 1 n-rings)))]
+  (let [((cons x xs)
+          (create-pids-one-arg 'ring n-msgs (: lists seq 1 n-rings)))]
     ;; Get it rolling.
     (! x (tuple 'pass (++ xs (list x)) 0))))
 
@@ -162,7 +163,8 @@
 
 
 (defun contact_stars
-  ;; This function sends a message to each of the individual stars in turn until the list is exhausted.
+  ;; This function sends a message to each of the individual stars in turn
+  ;; until the list is exhausted.
   ([()] 'done) ;; No more stars, we're done here.
   ([(cons x xs)]
    (: io format '"Sent message to star~n" '())
@@ -175,9 +177,9 @@
   ((n-stars n-msgs) (when (is_number n-stars) (is_number n-msgs))
    ;; Use the function from earlier to create our list of pids
    (let* [(stars (create-pids-one-arg 'star n-stars (: lists seq 1 n-stars)))
-          ;; For every message, trigger a sequence of communication with every star.
-          ;; This is inside the let* so I can deliberately discard the value and not
-          ;; be yelled at by the compiler.
+          ;; For every message, trigger a sequence of communication with every
+          ;; star. This is inside the let* so I can deliberately discard the
+          ;; value and not be yelled at by the compiler.
           (_ (lc ((<- _ (: lists seq 1 n-msgs))) (contact_stars stars)))]
      ;; Ensure all the star processes are killed off.
      (lc ((<- star stars)) (! star 'die)))))


### PR DESCRIPTION
Lots of little fixes:
- tabs -> spaces
- remove trailing whitespace
- convert some code comments to docstrings
- remove extra newlines on docstrings
- remove references to .lfe in script example
