### PR TITLE
Add expm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,12 @@ echo:
 	@ echo $(YSRCS)
 	@ echo $(EBINS)
 
-$(BINDIR):
-	mkdir -p $(BINDIR)
-
 $(EXPM): $(BINDIR)
 	curl -o $(EXPM) http://expm.co/__download__/expm
 	chmod +x $(EXPM)
 
 get-deps: $(EXPM)
+	@rebar get-deps
 
 get-version:
 	@echo
@@ -98,5 +96,5 @@ get-version:
 	@echo -n package.exs: ''
 	@grep version package.exs |awk '{print $$2}'|sed -e 's/,//g'
 
-upload: get-version
+upload: get-deps get-version
 	$(EXPM) publish

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ get-deps: $(EXPM)
 
 get-version:
 	@echo
+	@echo "Getting version info ..."
+	@echo
 	@echo -n app.src: ''
 	@erl -eval 'io:format("~p~n", [ \
 		proplists:get_value(vsn,element(3,element(2,hd(element(3, \
@@ -97,4 +99,7 @@ get-version:
 	@grep version package.exs |awk '{print $$2}'|sed -e 's/,//g'
 
 upload: get-deps get-version
+	@echo
+	@echo "Continue with upload? "
+	@read
 	$(EXPM) publish

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # This simple Makefile uses rebar to compile/clean if it
 # exists, else does it explicitly.
 
-BINDIR = ebin
+EBINDIR = ebin
 SRCDIR = src
 INCDIR = include
 DOCDIR = doc
@@ -24,8 +24,8 @@ INSTALLDIR = $(ERL_LIBS)/lfe-$(shell cat VERSION)
 
 .SUFFIXES: .erl .beam
 
-$(BINDIR)/%.beam: $(SRCDIR)/%.erl
-	$(ERLC) -I $(INCDIR) -o $(BINDIR) $(ERLCFLAGS) $<
+$(EBINDIR)/%.beam: $(SRCDIR)/%.erl
+	$(ERLC) -I $(INCDIR) -o $(EBINDIR) $(ERLCFLAGS) $<
 
 %.erl: %.xrl
 	$(ERLC) -o $(SRCDIR) $<
@@ -45,12 +45,12 @@ compile:
 	fi
 
 ## Compile using erlc
-erlc_compile: $(addprefix $(BINDIR)/, $(EBINS))
+erlc_compile: $(addprefix $(EBINDIR)/, $(EBINS))
 
 install:
 	if [ "$$ERL_LIBS" != "" ]; \
 	then mkdir -p $(INSTALLDIR) ; \
-	     cp -pPR $(BINDIR) $(INSTALLDIR); \
+	     cp -pPR $(EBINDIR) $(INSTALLDIR); \
 	     cp -pPR $(EMACSDIR) $(INSTALLDIR); \
 	     cp -pPR $(INCDIR) $(INSTALLDIR); \
 	else exit 1; \
@@ -61,7 +61,7 @@ docs:
 clean:
 	if which rebar > /dev/null; \
 	then rebar clean; \
-	else rm -rf $(BINDIR)/*.beam; \
+	else rm -rf $(EBINDIR)/*.beam; \
 	fi
 	rm -rf erl_crash.dump
 

--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,7 @@
+Expm.Package.new(name: "lfe",
+                 description: "Lisp Flavored Erlang",
+                 version: "0.6.2",
+                 keywords: ["LFE", "Lisp"],
+                 maintainers: [[name: "Robert Virding",
+                                email: "rvirding@gmail.com"]],
+                 repositories: [[github: "rvirding/lfe"]])


### PR DESCRIPTION
This change will allow Robert to execute `make upload` and publish LFE to expm.co:
- http://expm.co/

Note that in order for that to work, one will need to:
1. create an EXPM username : `./bin/expm config:set username rvirding`, and
2. create an EXPM password: `./bin/expm config:set password something-great`

There is a make target `get-version` which offers a sanity check that the `.app` file version and the `.exs` file version are the same. This is automatically called when performing the upload with `make upload`.

Once published, a page for LFE will be created like this one for loise:
- http://expm.co/loise

On this page, users can copy and paste the configuration setting that is pertinent to their chosen method of dependency management.

Also, using `expm` from the command line, users will be able to do such things as this:

```
$ ./bin/expm search lfe
lfe-utils            Utility functions for LFE
lfeunit              An eunit clone for LFE
loise                A Noise-Generator for LFE
```
