### PR TITLE
Added support for #| foo |# style block comments.

### DIFF
--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -32,8 +32,7 @@ WS	= ([\000-\s]|;[^\n]*)
 
 Rules.
 %% Bracketed Comments using #| foo |#
-#\|[^\|]*\|+([^#\|][^\|]*\|+)*# :
-  block_comment(string:substr(TokenChars, 3), TokenLine).
+#\|[^\|]*\|+([^#\|][^\|]*\|+)*# : block_comment(string:substr(TokenChars, 3)).
 %% Separators
 #[bB]\(		:	{token,{'#B(',TokenLine}}.
 #\(		:	{token,{'#(',TokenLine}}.
@@ -173,13 +172,11 @@ chars([]) -> [].
 %% comments because currently the parser cannot process them without
 %% a rebuild. But simply exploding on a '#|' is not going to be
 %% that helpful.
-block_comment(TokenChars, Line) ->
-  {ok, FindOpeningToken} = re:compile("(#\\|)+"),
-  case re:run(TokenChars, FindOpeningToken) of
-    {match, _} ->
-      {error, lists:concat(["illegal nested block comment line:", Line])};
-    _ ->
-      skip_token
+block_comment(TokenChars) ->
+  %% Check we're not opening another comment block.
+  case string:str(TokenChars, "#|") of
+    0 -> skip_token; %% No nesting found
+    _ -> {error, "illegal nested block comment"}
   end.
 
 hex_char(C) when C >= $0, C =< $9 -> true;

--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -32,7 +32,8 @@ WS	= ([\000-\s]|;[^\n]*)
 
 Rules.
 %% Bracketed Comments using #| foo |#
-#\|[^\|]*\|+([^#\|][^\|]*\|+)*# : skip_token.
+#\|[^\|]*\|+([^#\|][^\|]*\|+)*# :
+  block_comment(string:substr(TokenChars, 3), TokenLine).
 %% Separators
 #[bB]\(		:	{token,{'#B(',TokenLine}}.
 #\(		:	{token,{'#(',TokenLine}}.
@@ -166,6 +167,20 @@ chars([$\\,$x,C|Cs0]) ->
 chars([$\\,C|Cs]) -> [escape_char(C)|chars(Cs)];
 chars([C|Cs]) -> [C|chars(Cs)];
 chars([]) -> [].
+
+%% Block Comment:
+%% Provide a sensible error when people attempt to include nested
+%% comments because currently the parser cannot process them without
+%% a rebuild. But simply exploding on a '#|' is not going to be
+%% that helpful.
+block_comment(TokenChars, Line) ->
+  {ok, FindOpeningToken} = re:compile("(#\\|)+"),
+  case re:run(TokenChars, FindOpeningToken) of
+    {match, _} ->
+      {error, lists:concat(["illegal nested block comment line:", Line])};
+    _ ->
+      skip_token
+  end.
 
 hex_char(C) when C >= $0, C =< $9 -> true;
 hex_char(C) when C >= $a, C =< $f -> true;

--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -31,6 +31,8 @@ SSYM	= [^][()}{|";#`',\000-\s]
 WS	= ([\000-\s]|;[^\n]*)
 
 Rules.
+%% Bracketed Comments using #| foo |#
+#\|[^\|]*\|+([^#\|][^\|]*\|+)*# : skip_token.
 %% Separators
 #[bB]\(		:	{token,{'#B(',TokenLine}}.
 #\(		:	{token,{'#(',TokenLine}}.


### PR DESCRIPTION
This adds support for the following bracketed comment style : `#| comments! |#`. Resolves issue #21.

```
(defun (foo a b)
       (+ a b #| foo |# 3))
```

This is also legal...

```
(defun foo
       #| (let ((x (: io read_file 'bar)))
               (do-stuff x)) |#
               (no-really-do-stuff (: gief 'bar)))
```

As has been covered in every mention of this topic, this is not legal:

```
(defun foo
       #| (let (#| get info |# (x (: io read_file 'bar)))
               (do-stuff x)) |#
               (+ 3 3))
```

No nested comments for you!

I'm not sure if/how to add tests for this or if there is something I am missing.. :)
