### PR TITLE
Added support for fields-name record macro

### DIFF
--- a/doc/user_guide.txt
+++ b/doc/user_guide.txt
@@ -452,6 +452,7 @@ field-name value to get non-default values. E.g. for
 => (make-person {{field value}} ... )
    (match-person {{field value}} ... )
    (is-person r)
+   (fields-person)
    (emp-person {{field value}} ... )
    (set-person r {{field value}} ... )
    (person-name r)
@@ -500,6 +501,12 @@ field-name value to get non-default values. E.g. for
 
         In the person record john set the age field to 35 and the
         address field to "front street".
+
+(fields-person)
+
+        Returns a list of fields for the record. This is useful for when
+        using LFE with Mnesia, as the record field names don't have to be
+        provided manually in the create_table call.
 
 Binaries/bitstrings
 -------------------

--- a/examples/mnesia_demo.lfe
+++ b/examples/mnesia_demo.lfe
@@ -24,12 +24,17 @@
 (defmodule mnesia_demo
   (export (new 0) (by_place 1) (by_place_ms 1) (by_place_qlc 1)))
 
-(defrecord person name place job)
+(defrecord person
+  name
+  place
+  job)
 
 (defun new ()
   ;; Start mnesia and create a table, we will get an in memory only schema.
   (: mnesia start)
-  (: mnesia create_table 'person '(#(attributes (name place job))))
+  (: mnesia create_table
+     'person
+     `(#(attributes ,(fields-person))))
   ;; Initialise the table.
   (let ((people '(
           ;; First some people in London.

--- a/src/lfe_macro_record.erl
+++ b/src/lfe_macro_record.erl
@@ -72,6 +72,7 @@ defrecord(Name, Fdefs, Env, St0) ->
     Test = list_to_atom(concat(['is','-',Name])),
     EMP = list_to_atom(concat(['emp','-',Name])),
     Set = list_to_atom(concat(['set','-',Name])),
+    Recfields = list_to_atom(concat(['fields','-',Name])),
     %% Make access macros.
     {Fdef,St1} = defrec_fields(Fields, Name, St0), %Name is element 1!
     Macs = [['defmacro',Make,fds,
@@ -95,7 +96,8 @@ defrecord(Name, Fdefs, Env, St0) ->
 	       [l,fds,rec]]]],
 	    ['defmacro',EMP,fds,
 	      ['let',[[def,[list|lists:duplicate(length(Fields),?Q(?Q('_')))]]],
-	       ?BQ([tuple,?Q(Name),?UQ_S([Fu,fds,def])])]]
+	       ?BQ([tuple,?Q(Name),?UQ_S([Fu,fds,def])])]],
+        ['defmacro',Recfields,[],?BQ(?Q(Fields))]
 	    |
 	    Fdef],
     %% lfe_io:format("~p\n", [{Funs,Macs}]),


### PR DESCRIPTION
With this patch, when creating a record, a new macro will now be available for getting record info: (fields-name ...).

Both the docs and the mnesia example have been updated to use this new macro.
