### PR TITLE
Add the ability to customize the shell's abort message

### DIFF
--- a/doc/lfe_shell.txt
+++ b/doc/lfe_shell.txt
@@ -135,6 +135,27 @@ Starting the LFE shell
         will create a job running the LFE shell and connect to
         it. This also works when starting a remote shell.
 
+        When the shell starts, the user is presented with the following
+        message about quitting the shell prior to the first prompt:
+
+        LFE Shell V5.10.1 (abort with ^G)
+
+        For LFE shells not running on the Erlang VM, this may not be
+        an accurate or appropriate instruction. As such, this message
+        is configurable via an environment variable, allowing LFE shells
+        running on different VMs (with potentially different mechanisms
+        for quitting) to instruct their users appropriately.
+
+        For instance, this is how one would tell LFE on the JVM to use ^D
+        instead of ^G:
+
+        LFE_ABORT_MSG="(abort with ^D)" \
+            erl -noshell -noinput -s lfe_boot start
+
+        Which would give the following starting message:
+
+        LFE Shell V5.10.1 (abort with ^D)
+
 Running LFE shell scripts
 
         The LFE shell can also be directly called to run LFE shell
@@ -153,4 +174,3 @@ Running LFE shell scripts
                 A list of the arguments to the script as strings. If
                 no arguments have been given then this will be an
                 empty list.
-

--- a/doc/lfe_shell.txt
+++ b/doc/lfe_shell.txt
@@ -153,3 +153,4 @@ Running LFE shell scripts
                 A list of the arguments to the script as strings. If
                 no arguments have been given then this will be an
                 empty list.
+

--- a/src/lfe_shell.erl
+++ b/src/lfe_shell.erl
@@ -89,8 +89,15 @@ server(default) ->
     server(lfe_env:new());
 server(Env) ->
     process_flag(trap_exit, true),              %Must trap exists
-    io:fwrite("LFE Shell V~s (abort with ^G)\n",
-              [erlang:system_info(version)]),
+    Abrtmsg = fun () ->
+        Env = os:getenv("LFE_ABORT_MSG"),
+        case Env of
+        false -> "(abort with ^G)";
+        _ -> Env
+        end
+    end,
+    io:fwrite("LFE Shell V~s ~s\n",
+          [erlang:system_info(version),Abrtmsg()]),
     %% Create a default base env of predefined shell variables with
     %% default nil bindings and basic shell macros.
     St = new_state("lfe", [], Env),


### PR DESCRIPTION
When starting LFE on Erjang, the abort message is still the following

```
    LFE Shell V5.10.1 (abort with ^G)
```

This change allows one to specify an abort message via an environment variable, `LFE_ABORT_MSG`, such that the following

```
$ LFE_ABORT_MSG="(abort with ^D)" \
    erl -noshell -noinput -s lfe_boot start
```

or this:

```
$ LFE_ABORT_MSG="(abort with ^D)" \
    ./bin/lfe -pa ./ebin/
```

renders the starting shell message to be this:

```
    LFE Shell V5.10.1 (abort with ^D)
```

Those are, of course, not the VMs you'd want to change that message on ;-) This one, though, is:

```
$ LFE_ABORT_MSG="(abort with ^D)" \
    lfetool repl jlfe
```
