### PR TITLE
Develop

### DIFF
--- a/src/lfe_macro.erl
+++ b/src/lfe_macro.erl
@@ -612,13 +612,20 @@ exp_predef(['/'|Es], _, St0) ->
 	    {Exp,St1} = exp_arith(Es, '/', St0),
 	    {yes,Exp,St1}
     end;
-exp_predef([Op|Es], _, St0)			%Logical operators
-  when Op == '>'; Op == '>='; Op == '<'; Op == '=<';
-       Op == '=='; Op == '/='; Op == '=:='; Op == '=/=' ->
+exp_predef([Op|Es], _, St0)            %Logical operators
+  when Op == '>'; Op == '>='; Op == '<'; Op == '=<'; Op == '<=';
+       Op == '=='; Op == '/='; Op == '!='; Op == '=:='; Op == '==='; Op == '=/='; Op == '!==' ->
+    case Op of
+    '<=' -> EOp = '=<';
+    '!=' -> EOp = '/=';
+    '===' -> EOp = '=:=';
+    '!==' -> EOp = '=/=';
+    _ -> EOp = Op
+    end,
     case Es of
-	[_|_] ->
-	    {Exp,St1} = exp_comp(Es, Op, St0),
-	    {yes,Exp,St1}
+    [_|_] ->
+        {Exp,St1} = exp_comp(Es, EOp, St0),
+        {yes,Exp,St1}
     end;
 exp_predef([backquote,Bq], _, St) ->		%We do this here.
     {yes,exp_backquote(Bq),St};
@@ -966,7 +973,7 @@ exp_rules(Name, Keywords, Rules) ->
 	   [':',lfe_macro,mbe_syntax_rules_proc,
 	    [quote,Name],[quote,Keywords],[quote,Rules],args]]].
 
-%%  By André van Tonder
+%%  By Andrï¿½ van Tonder
 %%  Unoptimized.  See Dybvig source for optimized version.
 %%  Resembles one by Richard Kelsey and Jonathan Rees.
 %%   (define-syntax quasiquote

--- a/src/lfe_parse.erl
+++ b/src/lfe_parse.erl
@@ -99,6 +99,8 @@ reduce(3, [T|Vs]) -> [val(T)|Vs];    %s->string
 reduce(4, [T|Vs]) ->                 %s->fun
     [make_fun(val(T))|Vs];
 reduce(5, [S,_|Vs]) -> [[quote,S]|Vs];        %s->' s
+reduce(55, [T|Vs]) -> [[quote, val(T)] | Vs];
+
 reduce(6, [S,_|Vs]) -> [[backquote,S]|Vs];    %s->` s
 reduce(7, [S,_|Vs]) -> [[unquote,S]|Vs];      %s->, s
 reduce(8, [S,_|Vs]) ->               %s->,@ s
@@ -109,8 +111,8 @@ reduce(11, [_,L,_|Vs]) ->            %s->#( p )
     [list_to_tuple(L)|Vs];
 reduce(12, [_,L,B|Vs]) ->            %s->#B( p )
     case catch lfe_eval:expr([binary|L]) of
-	Bin when is_bitstring(Bin) -> [Bin|Vs];
-	_ -> {error,line(B),{illegal,binary}}
+    Bin when is_bitstring(Bin) -> [Bin|Vs];
+    _ -> {error,line(B),{illegal,binary}}
     end;
 reduce(13, [T,H|Vs]) -> [[H|T]|Vs];  %l->s t
 reduce(14, Vs) -> [[]|Vs];           %l->empty
@@ -124,74 +126,79 @@ reduce(19, Vs) -> [[]|Vs].           %p->empty
 table(?FORM, symbol) -> [?EXPR];
 table(?FORM, number) -> [?EXPR];
 table(?FORM, string) -> [?EXPR];
-table(?FORM, 'fun') -> [?EXPR];
-table(?FORM, '\'') -> [?EXPR];
-table(?FORM, '`') -> [?EXPR];
-table(?FORM, ',') -> [?EXPR];
-table(?FORM, ',@') -> [?EXPR];
-table(?FORM, '(') -> [?EXPR];
-table(?FORM, '[') -> [?EXPR];
-table(?FORM, '#(') -> [?EXPR];
-table(?FORM, '#B(') -> [?EXPR];
+table(?FORM, quoted_string) -> [?EXPR];
+table(?FORM, 'fun')  -> [?EXPR];
+table(?FORM, '\'')   -> [?EXPR];
+table(?FORM, '`')    -> [?EXPR];
+table(?FORM, ',')    -> [?EXPR];
+table(?FORM, ',@')   -> [?EXPR];
+table(?FORM, '(')    -> [?EXPR];
+table(?FORM, '[')    -> [?EXPR];
+table(?FORM, '#(')   -> [?EXPR];
+table(?FORM, '#B(')  -> [?EXPR];
 
-table(?EXPR, symbol) -> [symbol,{reduce,1}];
-table(?EXPR, number) -> [number,{reduce,2}];
-table(?EXPR, string) -> [string,{reduce,3}];
-table(?EXPR, 'fun') -> ['fun',{reduce,4}];
-table(?EXPR, '\'') -> ['\'',?EXPR,{reduce,5}];
-table(?EXPR, '`') -> ['`',?EXPR,{reduce,6}];
-table(?EXPR, ',') -> [',',?EXPR,{reduce,7}];
-table(?EXPR, ',@') -> [',@',?EXPR,{reduce,8}];
-table(?EXPR, '(') -> ['(',?LIST,')',{reduce,9}];
-table(?EXPR, '[') -> ['[',?LIST,']',{reduce,10}];
-table(?EXPR, '#(') -> ['#(',?PROP,')',{reduce,11}];
-table(?EXPR, '#B(') -> ['#B(',?PROP,')',{reduce,12}];
+table(?EXPR, symbol) -> [symbol, {reduce,1}];
+table(?EXPR, number) -> [number, {reduce,2}];
+table(?EXPR, string) -> [string, {reduce,3}];
+table(?EXPR, quoted_string) -> [quoted_string, {reduce, 55}];
+table(?EXPR, 'fun')  -> ['fun', {reduce,4}];
+table(?EXPR, '\'')   -> ['\'',  ?EXPR, {reduce,5}];
+table(?EXPR, '`')    -> ['`',   ?EXPR, {reduce,6}];
+table(?EXPR, ',')    -> [',',   ?EXPR, {reduce,7}];
+table(?EXPR, ',@')   -> [',@',  ?EXPR, {reduce,8}];
+table(?EXPR, '(')    -> ['(',   ?LIST, ')', {reduce,9}];
+table(?EXPR, '[')    -> ['[',   ?LIST, ']', {reduce,10}];
+table(?EXPR, '#(')   -> ['#(',  ?PROP, ')', {reduce,11}];
+table(?EXPR, '#B(')  -> ['#B(', ?PROP, ')', {reduce,12}];
 
 table(?LIST, symbol) -> [?EXPR,?TAIL,{reduce,13}];
 table(?LIST, number) -> [?EXPR,?TAIL,{reduce,13}];
 table(?LIST, string) -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, 'fun') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '\'') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '`') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, ',') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, ',@') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '(') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '[') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '#(') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, '#B(') -> [?EXPR,?TAIL,{reduce,13}];
-table(?LIST, ')') -> [{reduce,14}];
-table(?LIST, ']') -> [{reduce,14}];
+table(?LIST, quoted_string) -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, 'fun')  -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '\'')   -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '`')    -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, ',')    -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, ',@')   -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '(')    -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '[')    -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '#(')   -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, '#B(')  -> [?EXPR,?TAIL,{reduce,13}];
+table(?LIST, ')')    -> [{reduce,14}];
+table(?LIST, ']')    -> [{reduce,14}];
 
 table(?TAIL, symbol) -> [?EXPR,?TAIL,{reduce,15}];
 table(?TAIL, number) -> [?EXPR,?TAIL,{reduce,15}];
 table(?TAIL, string) -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, 'fun') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '\'') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '`') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, ',') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, ',@') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '(') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '[') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '#(') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '#B(') -> [?EXPR,?TAIL,{reduce,15}];
-table(?TAIL, '.') -> ['.',?EXPR,{reduce,16}];
-table(?TAIL, ')') -> [{reduce,17}];
-table(?TAIL, ']') -> [{reduce,17}];
+table(?TAIL, quoted_string) -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, 'fun')  -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '\'')   -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '`')    -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, ',')    -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, ',@')   -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '(')    -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '[')    -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '#(')   -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '#B(')  -> [?EXPR,?TAIL,{reduce,15}];
+table(?TAIL, '.')    -> ['.',?EXPR,{reduce,16}];
+table(?TAIL, ')')    -> [{reduce,17}];
+table(?TAIL, ']')    -> [{reduce,17}];
 
 table(?PROP, symbol) -> [?EXPR,?PROP,{reduce,18}];
 table(?PROP, number) -> [?EXPR,?PROP,{reduce,18}];
 table(?PROP, string) -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, 'fun') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '\'') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '`') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, ',') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, ',@') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '(') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '[') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '#(') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, '#B(') -> [?EXPR,?PROP,{reduce,18}];
-table(?PROP, ')') -> [{reduce,19}];
-table(?PROP, ']') -> [{reduce,19}];
+table(?PROP, quoted_string) -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, 'fun')  -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '\'')   -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '`')    -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, ',')    -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, ',@')   -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '(')    -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '[')    -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '#(')   -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, '#B(')  -> [?EXPR,?PROP,{reduce,18}];
+table(?PROP, ')')    -> [{reduce,19}];
+table(?PROP, ']')    -> [{reduce,19}];
 
 table(_, _) -> error.
 
@@ -200,11 +207,11 @@ table(_, _) -> error.
 %% sexpr(Continuation, Tokens) ->
 %%      {ok,Line,Sexpr,Rest} | {more,Continuation} | {error,Error,Rest}.
 
-sexpr(Ts) -> sexpr([], Ts).			%Start with empty state
+sexpr(Ts) -> sexpr([], Ts).            %Start with empty state
 
 sexpr(Cont, Ts) -> parse1(Cont, Ts).
 
--record(lp, {l=none,st=[],vs=[]}).		%Line, States, Values
+-record(lp, {l=none,st=[],vs=[]}).     %Line, States, Values
 
 %% parse1(Tokens) ->
 %%      {ok,Line,Sexpr,Rest} | {more,Continuation} | {error,Error,Rest}.
@@ -213,18 +220,18 @@ sexpr(Cont, Ts) -> parse1(Cont, Ts).
 %% This is the opt-level of the LL engine. It
 %% initialises/packs/unpacks the continuation information.
 
-parse1([], Ts) ->				%First call
-    Start = start(),				%The start state.
+parse1([], Ts) ->                           %First call
+    Start = start(),                        %The start state.
     parse1(#lp{l=none,st=[Start],vs=[]}, Ts);
-parse1(#lp{l=none}=Lp, [T|_]=Ts) ->		%Guarantee a start line
+parse1(#lp{l=none}=Lp, [T|_]=Ts) ->         %Guarantee a start line
     parse1(Lp#lp{l=line(T)}, Ts);
 parse1(#lp{l=L,st=St0,vs=Vs0}, Ts) ->
     case parse2(Ts, St0, Vs0) of
-	{done,Rest,[],[V]} -> {ok,L,V,Rest};
-	{more,[],St1,Vs1} -> {more,#lp{l=L,st=St1,vs=Vs1}};
-	{error,Line,Error,Rest,_,_} ->
-	    %% Can't really continue from errors here.
-	    {error,{Line,?MODULE,Error},Rest}
+    {done,Rest,[],[V]} -> {ok,L,V,Rest};
+    {more,[],St1,Vs1} -> {more,#lp{l=L,st=St1,vs=Vs1}};
+    {error,Line,Error,Rest,_,_} ->
+        %% Can't really continue from errors here.
+        {error,{Line,?MODULE,Error},Rest}
     end.
 
 %% parse2(Tokens, StateStack, ValueStack) ->
@@ -241,30 +248,30 @@ parse2(Ts, [{reduce,R}|St], Vs0) ->
     %% io:fwrite("p: ~p\n", [{R,Vs}]),
     %% Try to reduce values and push value on value stack.
     case reduce(R, Vs0) of
-	{error,L,E} -> {error,L,E,Ts,St,Vs0};
-	Vs1 -> parse2(Ts, St, Vs1)
+    {error,L,E} -> {error,L,E,Ts,St,Vs0};
+    Vs1 -> parse2(Ts, St, Vs1)
     end;
-parse2(Ts, [], Vs) -> {done,Ts,[],Vs};		%All done
+parse2(Ts, [], Vs) -> {done,Ts,[],Vs};          %All done
 parse2([T|Ts]=Ts0, [S|St]=St0, Vs) ->
     %% io:fwrite("p: ~p\n", [{St0,Ts0}]),
     %% Try to match token type against state on stack.
     case type(T) of
-	S -> parse2(Ts, St, [T|Vs]);		%Match
-	Type ->					%Try to predict
-	    case table(S, Type) of
-		error -> {error,line(T),{illegal,Type},Ts0,St0,Vs};
-		Top -> parse2(Ts0, Top ++ St, Vs)
-	    end
+    S -> parse2(Ts, St, [T|Vs]);                %Match
+    Type ->                                     %Try to predict
+        case table(S, Type) of
+        error -> {error,line(T),{illegal,Type},Ts0,St0,Vs};
+        Top -> parse2(Ts0, Top ++ St, Vs)
+        end
     end;
-parse2([], St, Vs) ->				%Need more tokens
+parse2([], St, Vs) ->                           %Need more tokens
     {more,[],St,Vs};
-parse2({eof,L}=Ts, St, Vs) ->			%No more tokens
+parse2({eof,L}=Ts, St, Vs) ->                   %No more tokens
     {error,L,{missing,token},Ts,St,Vs}.
 
 %% Access the fields of a token.
 type(T) -> element(1, T).
 line(T) -> element(2, T).
-val(T) -> element(3, T).
+val(T)  -> element(3, T).
 
 %% Convert a fun string to a fun sexpr.
 %%   "F/A" -> ['fun', F, A].

--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -34,11 +34,13 @@ Rules.
 %% Bracketed Comments using #| foo |#
 #\|[^\|]*\|+([^#\|][^\|]*\|+)*# : block_comment(string:substr(TokenChars, 3)).
 
-%% Quoted String
-'"(\\x{H}+;|\\.|[^"])*" :
+%% tripple quoted string
+%%  """abc""" == (list #\a #\b #\c)
+"""(\\x{H}+;|\\.|[^"])*""" :
     %% Strip quotes.
-    S = string:substr(TokenChars, 3, TokenLen - 3),
-    {token, {quoted_string, TokenLine, chars(S)}}.
+    S = string:substr(TokenChars, 4, TokenLen - 6),
+    {token, {string, TokenLine, chars(S)}}.
+
 
 %% Separators
 #[bB]\(  :    {token,{'#B(',TokenLine}}.
@@ -62,6 +64,7 @@ Rules.
             %% Strip quotes.
             S = string:substr(TokenChars, 2, TokenLen - 2),
             {token,{quoted_string,TokenLine,chars(S)}}.
+
 %% Symbols
 \|(\\x{H}+;|\\.|[^|])*\| :
             %% Strip quotes.

--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -77,7 +77,7 @@ Rules.
 #[oO]{O}+    :    base_token(string:substr(TokenChars, 3), 8, TokenLine).
 #[dD]{D}+    :    base_token(string:substr(TokenChars, 3), 10, TokenLine).
 #[xX]{H}+    :    base_token(string:substr(TokenChars, 3), 16, TokenLine).
-#{D}+[rR]{B36}+ :
+#([0]?[2-9]|[12][0-9]|3[0-6])[rR]{B36}+ :
     %% Have to scan all possible digit chars and fail if wrong.
     {Base,[_|Ds]} = base1(string:substr(TokenChars, 2), 10, 0),
     base_token(Ds, Base, TokenLine).
@@ -139,10 +139,10 @@ base_token(Cs, B, L) ->
 base1([C|Cs], Base, SoFar) when C >= $0, C =< $9, C < Base + $0 ->
     Next = SoFar * Base + (C - $0),
     base1(Cs, Base, Next);
-base1([C|Cs], Base, SoFar) when C >= $a, C =< $f, C < Base + $a - 10 ->
+base1([C|Cs], Base, SoFar) when C >= $a, C =< $z, C < Base + $a - 10 ->
     Next = SoFar * Base + (C - $a + 10),
     base1(Cs, Base, Next);
-base1([C|Cs], Base, SoFar) when C >= $A, C =< $F, C < Base + $A - 10 ->
+base1([C|Cs], Base, SoFar) when C >= $A, C =< $Z, C < Base + $A - 10 ->
     Next = SoFar * Base + (C - $A + 10),
     base1(Cs, Base, Next);
 base1([C|Cs], _Base, SoFar) -> {SoFar,[C|Cs]};

--- a/src/lfe_scan.xrl
+++ b/src/lfe_scan.xrl
@@ -17,75 +17,84 @@
 %% Purpose : Token definitions for Lisp Flavoured Erlang.
 
 Definitions.
-B	= [01]
-O	= [0-7]
-D	= [0-9]
-H	= [0-9a-fA-F]
-B36	= [0-9a-zA-Z]
-U	= [A-Z]
-L	= [a-z]
-A	= ({U}|{L})
-DEL	= [][()}{";\000-\s]
-SYM	= [^][()}{";\000-\s]
-SSYM	= [^][()}{|";#`',\000-\s]
-WS	= ([\000-\s]|;[^\n]*)
+B    = [01]
+O    = [0-7]
+D    = [0-9]
+H    = [0-9a-fA-F]
+B36  = [0-9a-zA-Z]
+U    = [A-Z]
+L    = [a-z]
+A    = ({U}|{L})
+DEL  = [][()}{";\000-\s]
+SYM  = [^][()}{";\000-\s]
+SSYM = [^][()}{|";#`',\000-\s]
+WS   = ([\000-\s]|;[^\n]*)
 
 Rules.
 %% Bracketed Comments using #| foo |#
 #\|[^\|]*\|+([^#\|][^\|]*\|+)*# : block_comment(string:substr(TokenChars, 3)).
+
+%% Quoted String
+'"(\\x{H}+;|\\.|[^"])*" :
+    %% Strip quotes.
+    S = string:substr(TokenChars, 3, TokenLen - 3),
+    {token, {quoted_string, TokenLine, chars(S)}}.
+
 %% Separators
-#[bB]\(		:	{token,{'#B(',TokenLine}}.
-#\(		:	{token,{'#(',TokenLine}}.
-#`		:	{token,{'#`',TokenLine}}.
-#;		:	{token,{'#;',TokenLine}}.
-#,		:	{token,{'#,',TokenLine}}.
-#,@		:	{token,{'#,@',TokenLine}}.
-'		:	{token,{'\'',TokenLine}}.
-`		:	{token,{'`',TokenLine}}.
-,		:	{token,{',',TokenLine}}.
-,@		:	{token,{',@',TokenLine}}.
-\.		:	{token,{'.',TokenLine}}.
-[][()}{]	:	{token,{list_to_atom(TokenChars),TokenLine}}.
+#[bB]\(  :    {token,{'#B(',TokenLine}}.
+#\(      :    {token,{'#(',TokenLine}}.
+#`       :    {token,{'#`',TokenLine}}.
+#;       :    {token,{'#;',TokenLine}}.
+#,       :    {token,{'#,',TokenLine}}.
+#,@      :    {token,{'#,@',TokenLine}}.
+'        :    {token,{'\'',TokenLine}}.
+`        :    {token,{'`',TokenLine}}.
+,        :    {token,{',',TokenLine}}.
+,@       :    {token,{',@',TokenLine}}.
+\.       :    {token,{'.',TokenLine}}.
+[][()}{] :    {token,{list_to_atom(TokenChars),TokenLine}}.
+
 %% Characters
-#\\(x{H}+|.)	:	char_token(string:substr(TokenChars, 3), TokenLine).
+#\\(x{H}+|.)    :    char_token(string:substr(TokenChars, 3), TokenLine).
+
 %% String
 "(\\x{H}+;|\\.|[^"])*" :
-			%% Strip quotes.
-			S = string:substr(TokenChars, 2, TokenLen - 2),
-			{token,{string,TokenLine,chars(S)}}.
+            %% Strip quotes.
+            S = string:substr(TokenChars, 2, TokenLen - 2),
+            {token,{quoted_string,TokenLine,chars(S)}}.
 %% Symbols
 \|(\\x{H}+;|\\.|[^|])*\| :
-			%% Strip quotes.
-			S = string:substr(TokenChars, 2, TokenLen - 2),
-			symbol_token(chars(S), TokenLine).
+            %% Strip quotes.
+            S = string:substr(TokenChars, 2, TokenLen - 2),
+            symbol_token(chars(S), TokenLine).
 %% Funs
-#'{SSYM}{SYM}*/{D}+	:
+#'{SSYM}{SYM}*/{D}+    :
             %% Strip sharpsign single-quote.
             FunStr = string:substr(TokenChars,3),
             {token,{'fun',TokenLine,FunStr}}.
 %% Based numbers
-#[bB]{B}+	:	base_token(string:substr(TokenChars, 3), 2, TokenLine).
-#[oO]{O}+	:	base_token(string:substr(TokenChars, 3), 8, TokenLine).
-#[dD]{D}+	:	base_token(string:substr(TokenChars, 3), 10, TokenLine).
-#[xX]{H}+	:	base_token(string:substr(TokenChars, 3), 16, TokenLine).
+#[bB]{B}+    :    base_token(string:substr(TokenChars, 3), 2, TokenLine).
+#[oO]{O}+    :    base_token(string:substr(TokenChars, 3), 8, TokenLine).
+#[dD]{D}+    :    base_token(string:substr(TokenChars, 3), 10, TokenLine).
+#[xX]{H}+    :    base_token(string:substr(TokenChars, 3), 16, TokenLine).
 #{D}+[rR]{B36}+ :
-	%% Have to scan all possible digit chars and fail if wrong.
-	{Base,[_|Ds]} = base1(string:substr(TokenChars, 2), 10, 0),
-	base_token(Ds, Base, TokenLine).
+    %% Have to scan all possible digit chars and fail if wrong.
+    {Base,[_|Ds]} = base1(string:substr(TokenChars, 2), 10, 0),
+    base_token(Ds, Base, TokenLine).
 %% Atoms
-[+-]?{D}+		:
-	case catch {ok,list_to_integer(TokenChars)} of
-	    {ok,I} -> {token,{number,TokenLine,I}};
-	    _ -> {error,"illegal integer"}
-	end.
+[+-]?{D}+        :
+    case catch {ok,list_to_integer(TokenChars)} of
+        {ok,I} -> {token,{number,TokenLine,I}};
+        _ -> {error,"illegal integer"}
+    end.
 [+-]?{D}+\.{D}+([eE][+-]?{D}+)? :
-	case catch {ok,list_to_float(TokenChars)} of
-	    {ok,F} -> {token,{number,TokenLine,F}};
-	    _ -> {error,"illegal float"}
-	end.
-{SSYM}{SYM}*	:
-	symbol_token(TokenChars, TokenLine).
-{WS}+		:	skip_token.
+    case catch {ok,list_to_float(TokenChars)} of
+        {ok,F} -> {token,{number,TokenLine,F}};
+        _ -> {error,"illegal float"}
+    end.
+{SSYM}{SYM}*    :
+    symbol_token(TokenChars, TokenLine).
+{WS}+        :    skip_token.
 
 Erlang code.
 %% Copyright (c) 2008-2013 Robert Virding
@@ -113,8 +122,8 @@ Erlang code.
 
 symbol_token(Cs, L) ->
     case catch {ok,list_to_atom(Cs)} of
-	{ok,S} -> {token,{symbol,L,S}};
-	_ -> {error,"illegal symbol"}
+    {ok,S} -> {token,{symbol,L,S}};
+    _ -> {error,"illegal symbol"}
     end.
 
 %% base_token(Chars, Base, Line) -> Integer.
@@ -123,8 +132,8 @@ symbol_token(Cs, L) ->
 
 base_token(Cs, B, L) ->
     case base1(Cs, B, 0) of
-	{N,[]} -> {token,{number,L,N}};
-	{_,_} -> {error,"illegal based number"}
+    {N,[]} -> {token,{number,L,N}};
+    {_,_} -> {error,"illegal based number"}
     end.
 
 base1([C|Cs], Base, SoFar) when C >= $0, C =< $9, C < Base + $0 ->
@@ -145,8 +154,8 @@ base1([], _Base, N) -> {N,[]}.
 
 char_token([$x,C|Cs], L) ->
     case base1([C|Cs], 16, 0) of
-	{N,[]} -> {token,{number,L,N}};
-	_ -> {error,"illegal character"}
+    {N,[]} -> {token,{number,L,N}};
+    _ -> {error,"illegal character"}
     end;
 char_token([C], L) -> {token,{number,L,C}}.
 
@@ -156,12 +165,12 @@ char_token([C], L) -> {token,{number,L,C}}.
 
 chars([$\\,$x,C|Cs0]) ->
     case hex_char(C) of
-	true ->
-	    case base1([C|Cs0], 16, 0) of
-		{N,[$;|Cs1]} -> [N|chars(Cs1)];
-		_Other -> [escape_char($x)|chars([C|Cs0])]
-	    end;
-	false -> [escape_char($x)|chars([C|Cs0])]
+    true ->
+        case base1([C|Cs0], 16, 0) of
+        {N,[$;|Cs1]} -> [N|chars(Cs1)];
+        _Other -> [escape_char($x)|chars([C|Cs0])]
+        end;
+    false -> [escape_char($x)|chars([C|Cs0])]
     end;
 chars([$\\,C|Cs]) -> [escape_char(C)|chars(Cs)];
 chars([C|Cs]) -> [C|chars(Cs)];
@@ -184,13 +193,13 @@ hex_char(C) when C >= $a, C =< $f -> true;
 hex_char(C) when C >= $A, C =< $F -> true;
 hex_char(_) -> false.
 
-escape_char($n) -> $\n;				%\n = LF
-escape_char($r) -> $\r;				%\r = CR
-escape_char($t) -> $\t;				%\t = TAB
-escape_char($v) -> $\v;				%\v = VT
-escape_char($b) -> $\b;				%\b = BS
-escape_char($f) -> $\f;				%\f = FF
-escape_char($e) -> $\e;				%\e = ESC
-escape_char($s) -> $\s;				%\s = SPC
-escape_char($d) -> $\d;				%\d = DEL
+escape_char($n) -> $\n;                %\n = LF
+escape_char($r) -> $\r;                %\r = CR
+escape_char($t) -> $\t;                %\t = TAB
+escape_char($v) -> $\v;                %\v = VT
+escape_char($b) -> $\b;                %\b = BS
+escape_char($f) -> $\f;                %\f = FF
+escape_char($e) -> $\e;                %\e = ESC
+escape_char($s) -> $\s;                %\s = SPC
+escape_char($d) -> $\d;                %\d = DEL
 escape_char(C) -> C.


### PR DESCRIPTION
Made integer with radix 17 ~ 36 to work like Erlang. Currently it does not, for example.

```
> #36rFF
555
> #36rGG
exception exit: #(error #(1 lfe_scan #(user "illegal based number")) 1)
  in (lfe_io scan_and_parse 3)
  in (lfe_shell server_loop 1)
  in (erl_eval do_apply 6)
  in (shell exprs 7)
  in (shell eval_exprs 7)
  in (shell eval_loop 3)

> #37rFF
570
```

Changes in lfe_scan.xrl

```
#([0]?[2-9]|[12][0-9]|3[0-6])[rR]{B36}+ :
    %% Have to scan all possible digit chars and fail if wrong.
    {Base,[_|Ds]} = base1(string:substr(TokenChars, 2), 10, 0),
    base_token(Ds, Base, TokenLine).

base1([C|Cs], Base, SoFar) when C >= $0, C =< $9, C < Base + $0 ->
    Next = SoFar * Base + (C - $0),
    base1(Cs, Base, Next);
base1([C|Cs], Base, SoFar) when C >= $a, C =< $z, C < Base + $a - 10 ->
    Next = SoFar * Base + (C - $a + 10),
    base1(Cs, Base, Next);
base1([C|Cs], Base, SoFar) when C >= $A, C =< $Z, C < Base + $A - 10 ->
    Next = SoFar * Base + (C - $A + 10),
    base1(Cs, Base, Next);
base1([C|Cs], _Base, SoFar) -> {SoFar,[C|Cs]};
base1([], _Base, N) -> {N,[]}.
```

After the change it works like below.

```
> #36rFF
555
> #36Rgg
592
> #37rFF
exception exit: #(error #(1 lfe_scan #(illegal "#37")) 1)
  in (lfe_io scan_and_parse 3)
  in (lfe_shell server_loop 1)
  in (erl_eval do_apply 6)
  in (shell exprs 7)
  in (shell eval_exprs 7)
  in (shell eval_loop 3)

> 
```
