### PR TITLE
fixed when using paredit-mode

### DIFF
--- a/emacs/lfe-mode.el
+++ b/emacs/lfe-mode.el
@@ -95,8 +95,6 @@ Other commands:
   (setq normal-auto-fill-function 'lisp-mode-auto-fill)
   (make-local-variable 'indent-line-function)
   (setq indent-line-function 'lisp-indent-line)
-  (make-local-variable 'indent-region-function)
-  (setq indent-region-function 'lisp-indent-region)
   (make-local-variable 'parse-sexp-ignore-comments)
   (setq parse-sexp-ignore-comments t)
   (make-local-variable 'outline-regexp)


### PR DESCRIPTION
I use paredit.el. When I run paredit-forward-slurp-sexp command in paredit.el, "void-function error" about lisp-indent-region occur.  When I delete 2 line in lfe-mode.lfe, The error does not occur.
