### PR TITLE
lfe-mode.el tweaks and additions

### DIFF
--- a/emacs/lfe-mode.el
+++ b/emacs/lfe-mode.el
@@ -15,12 +15,16 @@
 ;; limitations under the License.
 
 ;;; Author Robert Virding
-;;;
-;;; Copied from lisp-mode and scheme-mode and modified for LFE.
+
+;;; Commentary:
+;; Copied from `lisp-mode' and `scheme-mode' and modified for LFE.
 
 ;;; Code:
 
 (require 'lisp-mode)
+
+(defconst lfe--prettify-symbols-alist '(("lambda"  . ?λ))
+  "Prettfy symbols alist user in Lisp Flavoured Erlang mode.")
 
 (defvar lfe-mode-syntax-table
   (let ((table (copy-syntax-table lisp-mode-syntax-table)))
@@ -45,21 +49,21 @@
 ;;   (setq lfe-mode-map (copy-keymap lisp-mode-map))
 ;;   (define-key lfe-mode-map "\e[" 'lfe-insert-brackets))
 
-(defun lfe-insert-brackets (&optional arg)
-  "Enclose following ARG sexps in brackets.
-Leave point after open-bracket."
-  (interactive "P")
-  (insert-pair arg ?\[ ?\]))
-
 (defvar lfe-mode-abbrev-table ()
   "Abbrev table used in Lisp Flavoured Erlang mode.")
 
 (defvar lfe-mode-hook nil
   "*Hook for customizing Inferior LFE mode.")
 
+(defun lfe-insert-brackets (&optional arg)
+  "Enclose following `ARG' sexps in brackets.
+Leave point after open-bracket."
+  (interactive "P")
+  (insert-pair arg ?\[ ?\]))
+
 ;;;###autoload
 (defun lfe-mode ()
-  "Major mode for editing Lisp Flavoured Erlang. It's just like lisp mode.
+  "Major mode for editing Lisp Flavoured Erlang.  It's just like `lisp-mode'.
 
 Other commands:
 \\{lfe-mode-map}"
@@ -69,13 +73,14 @@ Other commands:
   (setq mode-name "LFE")
   (lfe-mode-variables)
   (use-local-map lfe-mode-map)
-;;   ;; For making font-lock case independant, which LFE isn't.
-;;   (make-local-variable 'font-lock-keywords-case-fold-search)
-;;   (setq font-lock-keywords-case-fold-search t)
+  ;;   ;; For making font-lock case independent, which LFE isn't.
+  ;;   (make-local-variable 'font-lock-keywords-case-fold-search)
+  ;;   (setq font-lock-keywords-case-fold-search t)
   (setq imenu-case-fold-search t)
   (run-mode-hooks 'lfe-mode-hook))
 
 (defun lfe-mode-variables ()
+  "Variables for LFE modes."
   (set-syntax-table lfe-mode-syntax-table)
   (setq local-abbrev-table lfe-mode-abbrev-table)
   (make-local-variable 'paragraph-start)
@@ -126,9 +131,10 @@ Other commands:
 	'((lfe-font-lock-keywords
 	   lfe-font-lock-keywords-1 lfe-font-lock-keywords-2)
 	  nil nil (("+-*/.<>=!?$%_&~^:@" . "w")) beginning-of-defun
-	  (font-lock-mark-block-function . mark-defun))))
+	  (font-lock-mark-block-function . mark-defun)))
+  (setq-local prettify-symbols-alist lfe--prettify-symbols-alist))
 
-;; Font locking
+;;; Font locking
 
 (defconst lfe-font-lock-keywords-1
   (eval-when-compile
@@ -138,7 +144,7 @@ Other commands:
 		   "\\(ine\\(-module\\|-function\\|-macro\\|"
 		   "-syntax\\|-record\\)?\\)\\|"
 		   ;; New model function names
-		   "\\(un\\|macro\\|syntax\\)\\|"
+		   "\\(un\\|macro\\|syntax\\|test\\)\\|"
 		   ;; New model other names
 		   "\\(module\\)\\|"
 		   "\\(record\\)"
@@ -168,34 +174,35 @@ Other commands:
     "LFE builtin functions (BIFs)"))
 
 (defconst lfe-font-lock-keywords-2
-  (append lfe-font-lock-keywords-1
+  (append
+   lfe-font-lock-keywords-1
    (eval-when-compile
      (list
       ;; Control structures.
       (cons
        (concat
-	"(" (regexp-opt
-	     '(;; Core forms.
-	       "cons" "car" "cdr" "list" "tuple" "binary"
-	       "after" "call" "case" "catch"
-	       "if" "lambda" "let" "let-function" "letrec-function"
-	       "let-macro" "match-lambda"
-	       "receive" "try" "funcall" "when" "progn"
-	       "eval-when-compile"
-	       ;; Default macros
-	       "caar" "cadr" "cdar" "cddr"
-	       "andalso" "cond" "do" "fun" "list*" "let*" "flet*" "macro"
-	       "orelse" "syntax-rules" "lc" "bc" "flet" "fletrec"
-	       "macrolet" "syntaxlet" "begin" "let-syntax"
-	       ;; Should the map forms be here or as type bifs?
-	       "map" "mref" "mset" "mupd" "map-get" "map-set" "map-update"
-	       "match-spec" "qlc"
-	       ":" "?" "++") t)
-	"\\>") '(1 font-lock-keyword-face))
+        "(" (regexp-opt
+             '(;; Core forms.
+               "cons" "car" "cdr" "list" "tuple" "binary"
+               "after" "call" "case" "catch"
+               "if" "lambda" "let" "let-function" "letrec-function"
+               "let-macro" "match-lambda"
+               "receive" "try" "funcall" "when" "progn"
+               "eval-when-compile"
+               ;; Default macros
+               "caar" "cadr" "cdar" "cddr"
+               "andalso" "cond" "do" "fun" "list*" "let*" "flet*" "macro"
+               "orelse" "syntax-rules" "lc" "bc" "flet" "fletrec"
+               "macrolet" "syntaxlet" "begin" "let-syntax"
+               ;; Should the map forms be here or as type bifs?
+               "map" "mref" "mset" "mupd" "map-get" "map-set" "map-update"
+               "match-spec" "qlc"
+               ":" "?" "++") t)
+        "\\>") '(1 font-lock-keyword-face))
       ;; Type tests.
       (cons
        (concat
-	"(" (regexp-opt (append lfe-type-tests lfe-type-bifs) t) "\\>")
+        "(" (regexp-opt (append lfe-type-tests lfe-type-bifs) t) "\\>")
        '(1 font-lock-builtin-face))
       )))
   "Gaudy expressions to highlight in LFE modes.")
@@ -203,11 +210,17 @@ Other commands:
 (defvar lfe-font-lock-keywords lfe-font-lock-keywords-1
   "Default expressions to highlight in LFE modes.")
 
+;;; Lisp indent
+
 (defvar calculate-lisp-indent-last-sexp)
 
-;; Copied from lisp-indent-function, but with gets of
-;; lfe-indent-{function,hook}.
 (defun lfe-indent-function (indent-point state)
+  "`INDENT-POINT' is the position where the user typed TAB, or equivalent.
+Point is located at the point to indent under;
+`STATE' is the `parse-partial-sexp' state for that position.
+
+Copied from function `lisp-indent-function',
+but with gets of lfe-indent-{function,hook}."
   (let ((normal-indent (current-column)))
     (goto-char (1+ (elt state 1)))
     (parse-partial-sexp (point) calculate-lisp-indent-last-sexp 0 t)
@@ -241,54 +254,71 @@ Other commands:
 	       (lisp-indent-specform method state
 				     indent-point normal-indent))
 	      (method
-		(funcall method state indent-point normal-indent)))))))
+               (funcall method state indent-point normal-indent)))))))
 
+;;; Indentation rule helpers
+;; Modified from `clojure-mode'.
 
-;; Special indentation rules. "def" anything is already fixed!
+(defun put-lfe-indent (sym indent)
+  "Instruct `lfe-indent-function' to indent the body of `SYM' by `INDENT'."
+  (put sym 'lfe-indent-function indent))
 
-;; (put 'begin 'lfe-indent-function 0), say, causes begin to be indented
+(defmacro define-lfe-indent (&rest kvs)
+  "Call `put-lfe-indent' on a series, `KVS'."
+  `(progn
+     ,@(mapcar (lambda (x)
+                 `(put-lfe-indent (quote ,(car x)) ,(cadr x)))
+               kvs)))
+
+;;; Special indentation rules
+;; "def" anything is already fixed!
+
+;; (define-lfe-indent (begin 0)), say, causes begin to be indented
 ;; like defun if the first form is placed on the next line, otherwise
 ;; it is indented like any other form (i.e. forms line up under first).
 
-;; Old style forms.
-(put 'begin 'lfe-indent-function 0)
-(put 'let-syntax 'lfe-indent-function 1)
-(put 'syntax-rules 'lfe-indent-function 0)
-(put 'macro 'lfe-indent-function 0)
-;; New style forms.
-;; Core forms.
-(put 'progn 'lfe-indent-function 0)
-(put 'lambda 'lfe-indent-function 1)
-(put 'match-lambda 'lfe-indent-function 0)
-(put 'let 'lfe-indent-function 1)
-(put 'let-function 'lfe-indent-function 1)
-(put 'letrec-function 'lfe-indent-function 1)
-(put 'let-macro 'lfe-indent-function 1)
-(put 'if 'lfe-indent-function 1)
-(put 'case 'lfe-indent-function 1)
-(put 'receive 'lfe-indent-function 0)
-(put 'catch 'lfe-indent-function 0)
-(put 'try 'lfe-indent-function 1)
-(put 'after 'lfe-indent-function 1)
-(put 'call 'lfe-indent-function 2)
-(put 'when 'lfe-indent-function 0)
-(put 'eval-when-compile 'lfe-indent-function 0)
-;; Core macros.
-(put ': 'lfe-indent-function 2)
-(put 'let* 'lfe-indent-function 1)
-(put 'flet 'lfe-indent-function 1)
-(put 'flet* 'lfe-indent-function 1)
-(put 'fletrec 'lfe-indent-function 1)
-(put 'macrolet 'lfe-indent-function 1)
-(put 'syntaxlet 'lfe-indent-function 1)
-(put 'do 'lfe-indent-function 2)
-(put 'lc 'lfe-indent-function 1)
-(put 'bc 'lfe-indent-function 1)
-(put 'match-spec 'lfe-indent-function 0)
+(define-lfe-indent
+  ;; Old style forms.
+  (begin 0)
+  (let-syntax 1)
+  (syntax-rules 0)
+  (macro 0)
+
+  ;; New style forms.
+  ;; Core forms.
+  (progn 0)
+  (lambda 1)
+  (match-lambda 0)
+  (let 1)
+  (let-function 1)
+  (letrec-function 1)
+  (let-macro 1)
+  (if 1)
+  (case 1)
+  (receive 0)
+  (catch 0)
+  (try 1)
+  (after 1)
+  (call 2)
+  (when 0)
+  (eval-when-compile 0)
+
+  ;; Core macros.
+  (: 2)
+  (let* 1)
+  (flet 1)
+  (flet* 1)
+  (fletrec 1)
+  (macrolet 1)
+  (syntaxlet 1)
+  (do 2)
+  (lc 1)
+  (bc 1)
+  (match-spec 0))
 
 ;;;###autoload
-;; Associate ".lfe" with LFE mode.
-(add-to-list 'auto-mode-alist '("\\.lfe\\'" . lfe-mode) t)
+;; Associate ".lfe{s,sh}?" with LFE mode.
+(add-to-list 'auto-mode-alist '("\\.lfe\\(?:s\\|sh\\)\\'" . lfe-mode) t)
 
 ;;;###autoload
 ;; Ignore files ending in ".jam", ".vee", and ".beam" when performing


### PR DESCRIPTION
I've prepared a squashed commit of some tweaks I've been enjoying locally.
- Add pretty lambdas
- Add slightly modified helper function/macro from [clojure-mode.el](https://github.com/clojure-emacs/clojure-mode/blob/aab633ffbb02884a11ae7fa1d6aa610beab75b61/clojure-mode.el#L773-L874)
- various cosmetic tweaks
- Flycheck appeasement
- Add highlighting for deftest forms
- Add .lfes and .lfesh to 'auto-mode-alist

For a commit-separated diff see [rvirding/lfe@5f3e147...yurrriq/lfe@867846f](https://github.com/rvirding/lfe/compare/5f3e147dee7ae3921d5c2bbd5e68dd2fc6995767...yurrriq:867846f0c3988f913b786a8595dfc3ef6f1ebc39).
### Examples
#### [xlfe/anagram/anagram-tests.lfe](https://github.com/exercism/xlfe/blob/master/anagram/anagram-tests.lfe)

![image](https://cloud.githubusercontent.com/assets/1866448/8816241/da02fb0e-2fe9-11e5-8aba-e8aefb03c9aa.png)
#### [xlfe/anagram/example.lfe](https://github.com/exercism/xlfe/blob/master/anagram/example.lfe)

![image](https://cloud.githubusercontent.com/assets/1866448/8816313/e66223a6-2fea-11e5-8ce4-e46be2e30e88.png)
