### PR TITLE
Update object examples

### DIFF
--- a/examples/internal-state.lfe
+++ b/examples/internal-state.lfe
@@ -1,4 +1,4 @@
-;; Copyright (c) 2013 Duncan McGreggor <oubiwann@cogitat.io>
+;; Copyright (c) 2013 Duncan McGreggor <oubiwann@gmail.com>
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -22,41 +22,40 @@
 ;;
 ;; To use the code below in LFE, do the following:
 ;;
-;;  $ cd examples
-;;  $ ../bin/lfe -pa ../ebin
+;;  $ ./bin/lfe -pa ./ebin
 ;;
-;; > (slurp '"internal-state.lfe")
+;; > (slurp "examples/internal-state.lfe")
 ;; #(ok internal-state)
-;; > (set account (new-account '"Alice" 100.00 0.06))
+;; > (set acct (new-account "Alice" 100.00 0.06))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (name account)
+;; > (send acct 'name)
 ;; "Alice"
-;; > (balance account)
+;; > (send acct 'balance)
 ;; 100.0
-;; > (set account (interest account))
+;; > (set acct (send acct 'apply-interest))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (balance account)
+;; > (send acct 'balance)
 ;; 106.0
-;; > (set account (withdraw account 54.90))
+;; > (set acct (send acct 'withdraw 54.90))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (set account (withdraw account 54.90))
+;; > (set acct (send acct 'withdraw 54.90))
 ;; exception error: insufficient-funds
 ;;
-;; > (balance account)
+;; > (send acct 'balance)
 ;; 51.1
-;; > (set account (deposit account 1000))
+;; > (set acct (send acct 'deposit 1000))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (set account (withdraw account 54.90))
+;; > (set acct (send acct 'withdraw 54.90))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (set account (withdraw account 54.90))
+;; > (set acct (send acct 'withdraw 54.90))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (set account (withdraw account 54.90))
+;; > (set acct (send acct 'withdraw 54.90))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (balance account)
+;; > (send acct 'balance)
 ;; 886.4
-;; > (set account (interest account))
+;; > (set acct (send acct 'apply-interest))
 ;; #Fun<lfe_eval.10.53503600>
-;; > (balance account)
+;; > (send acct 'balance)
 ;; 939.584
 
 (defmodule internal-state
@@ -68,38 +67,22 @@
       ('withdraw (lambda (amt)
                     (if (=< amt balance)
                         (new-account name (- balance amt) interest-rate)
-                        (: erlang error 'insufficient-funds))))
+                        (error 'insufficient-funds))))
       ('deposit (lambda (amt) (new-account name (+ balance amt) interest-rate)))
       ('balance (lambda () balance))
       ('name (lambda () name))
-      ('interest (lambda ()
+      ('apply-interest (lambda ()
                     (new-account
                       name
                       (+ balance (* balance interest-rate))
                       interest-rate))))))
 
-(defun get-method (object command)
-  (funcall object command))
+(defun send (object method-name)
+  "This is a generic function, used to call into the given object (class
+  instance)."
+  (funcall (funcall object method-name)))
 
-(defun send (object command arg)
-  (funcall (get-method object command) arg))
-
-(defun withdraw (object amt)
-  "Returns an updated account object."
-  (funcall (get-method object 'withdraw) amt))
-
-(defun deposit (object amt)
-  "Returns an updated account object."
-  (funcall (get-method object 'deposit) amt))
-
-(defun balance (object)
-  "Returns a float representing the balance."
-  (funcall (get-method object 'balance)))
-
-(defun name (object)
-  "Returns a string represnting the account holder."
-  (funcall (get-method object 'name)))
-
-(defun interest (object)
-  "Returns an updated account object."
-  (funcall (get-method object 'interest)))
+(defun send (object method-name arg)
+  "This is a generic function, used to call into the given object (class
+  instance)."
+  (funcall (funcall object method-name) arg))

--- a/examples/object-via-process.lfe
+++ b/examples/object-via-process.lfe
@@ -1,4 +1,4 @@
-;; Copyright (c) 2013 Duncan McGreggor <oubiwann@cogitat.io>
+;; Copyright (c) 2013 Duncan McGreggor <oubiwann@gmail.com>
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -26,143 +26,112 @@
 ;;
 ;; To use the code below in LFE, do the following:
 ;;
-;;  $ cd examples
-;;  $ ../bin/lfe -pa ../ebin
+;;  $ ./bin/lfe -pa ./ebin
 ;;
 ;; Load the file and create a fish-class instance:
 ;;
-;; > (slurp '"object-via-process.lfe")
+;; > (slurp "examples/object-via-process.lfe")
 ;; #(ok object-via-process)
-;; > (set mommy-fish (fish-class '"Carp"))
+;; > (set mommy-fish (init-fish "Carp"))
 ;; <0.33.0>
 ;;
 ;; Execute some of the basic methods:
 ;;
-;; > (get-species mommy-fish)
+;; > (send mommy-fish 'species)
 ;; "Carp"
-;; > (move mommy-fish 17)
-;; The Carp swam 17 feet!
-;; ok
-;; > (get-id mommy-fish)
+;; > (send mommy-fish 'move 17)
+;; "The Carp swam 17 feet!"
+;; > (send mommy-fish 'id)
 ;; "47eebe91a648f042fc3fb278df663de5"
 ;;
 ;; Now let's look at modifying state data (e.g., children counts):
 ;;
-;; > (get-children mommy-fish)
+;; > (send mommy-fish 'children)
 ;; ()
-;; > (get-children-count mommy-fish)
+;; > (send mommy-fish 'children-count)
 ;; 0
-;; > (set baby-fish-1 (reproduce mommy-fish))
+;; > (set baby-fish-1 (send mommy-fish 'reproduce))
 ;; <0.34.0>
-;; > (get-id mommy-fish)
-;; "47eebe91a648f042fc3fb278df663de5"
-;; > (get-id baby-fish-1)
+;; > (send baby-fish-1 'id)
 ;; "fdcf35983bb496650e558a82e34c9935"
-;; > (get-children-count mommy-fish)
+;; > (send mommy-fish 'children-count)
 ;; 1
-;; > (set baby-fish-2 (reproduce mommy-fish))
+;; > (set baby-fish-2 (send mommy-fish 'reproduce))
 ;; <0.35.0>
-;; > (get-id mommy-fish)
-;; "47eebe91a648f042fc3fb278df663de5"
-;; > (get-id baby-fish-2)
+;; > (send baby-fish-2 'id)
 ;; "3e64e5c20fb742dd88dac1032749c2fd"
-;; > (get-children-count mommy-fish)
+;; > (send mommy-fish 'children-count)
 ;; 2
-;; > (get-info mommy-fish)
-;; id: 47eebe91a648f042fc3fb278df663de5
-;; species: Carp
-;; children: ["fdcf35983bb496650e558a82e34c9935",
-;;            "3e64e5c20fb742dd88dac1032749c2fd"]
-;; ok
+;; > (send mommy-fish 'info)
+;; (#(id "f05064ffcf92d7b3e72968fd481abbd0")
+;;  #(species "Carp")
+;;  #(children
+;;    ("d53a426c732c938f996a1c2520bb621f" "15fede691ab3f96e9e3df248d37b7b55")))
 
 (defmodule object-via-process
  (export all))
 
-(defun fish-class (species)
+(defun init-fish (species)
   "This is the constructor that will be used most often, only requiring that
   one pass a 'species' string.
 
   When the children are not defined, simply use an empty list."
-  (fish-class species ()))
+  (init-fish species ()))
 
-(defun fish-class (species children)
+(defun init-fish (species children)
   "This constructor is useful for two reasons:
     1) as a way of abstracting out the id generation from the
        larger constructor, and
     2) spawning the 'object loop' code (fish-class/3)."
-  (let* (((binary (id (size 128))) (: crypto rand_bytes 16))
+  (let* (((binary (id (size 128))) (crypto:rand_bytes 16))
          (formatted-id (car
-                         (: io_lib format
-                           '"~32.16.0b" (list id)))))
-    (spawn 'object-via-process
-           'fish-class
-           (list species children formatted-id))))
+                         (io_lib:format "~32.16.0b" `(,id)))))
+    (spawn (lambda ()
+             (fish-class species children formatted-id)))))
 
 (defun fish-class (species children id)
   "This function is intended to be spawned as a separate process which is
   used to track the state of a fish. In particular, fish-class/2 spawns
   this function (which acts as a loop, pattern matching for messages)."
-  (let ((move-verb '"swam"))
+  (let ((move-verb "swam"))
     (receive
-      ((tuple caller 'move distance)
-        (! caller (list species move-verb distance))
+      (`#(,caller move ,distance)
+       (! caller (lists:flatten
+                  (io_lib:format "The ~s ~s ~p feet!"
+                                 `(,species ,move-verb ,distance))))
         (fish-class species children id))
-      ((tuple caller 'species)
+      (`#(,caller species ())
         (! caller species)
         (fish-class species children id))
-      ((tuple caller 'children)
+      (`#(,caller children ())
         (! caller children)
         (fish-class species children id))
-      ((tuple caller 'children-count)
+      (`#(,caller children-count ())
         (! caller (length children))
         (fish-class species children id))
-      ((tuple caller 'id)
-        (! caller id)
+      (`#(,caller id ())
+        (! caller (lists:flatten id))
         (fish-class species children id))
-      ((tuple caller 'info)
-        (! caller (list id species children))
+      (`#(,caller info ())
+       (! caller `(#(id ,id)
+                   #(species ,species)
+                   #(children ,children)))
         (fish-class species children id))
-      ((tuple caller 'reproduce)
-        (let* ((child (fish-class species))
-               (child-id (get-id child))
-               (children-ids (: lists append
-                               (list children (list child-id)))))
-        (! caller child)
-        (fish-class species children-ids id))))))
+      (`#(,caller reproduce ())
+        (let* ((child (init-fish species))
+               (child-id (send child 'id))
+               (children-ids (lists:append children `(,child-id))))
+          (! caller child)
+          (fish-class species children-ids id))))))
 
-(defun call-method (object method-name)
+(defun send (object method-name)
   "This is a generic function, used to call into the given object (class
   instance)."
-  (! object (tuple (self) method-name))
+  (send object method-name '()))
+
+(defun send (object method-name arg)
+  "This is a generic function, used to call into the given object (class
+  instance)."
+  (! object `#(,(self) ,method-name ,arg))
   (receive
     (data data)))
-
-(defun call-method (object method-name arg)
-  "Same as above, but with an additional argument."
-  (! object (tuple (self) method-name arg))
-  (receive
-    (data data)))
-
-(defun get-id (object)
-  "Define object methods."
-  (call-method object 'id))
-
-(defun get-species (object)
-  (call-method object 'species))
-
-(defun get-info (object)
-  (let ((data (call-method object 'info)))
-    (: io format '"id: ~s~nspecies: ~s~nchildren: ~p~n" data)))
-
-(defun move (object distance)
-  (let ((data (call-method object 'move distance)))
-    (: io format '"The ~s ~s ~p feet!~n" data)))
-
-(defun reproduce (object)
-  (call-method object 'reproduce))
-
-(defun get-children (object)
-  (call-method object 'children))
-
-(defun get-children-count (object)
-  (call-method object 'children-count))


### PR DESCRIPTION
These examples used old syntax (and in some cases, deprecated syntax). I've also cleaned them up to be consistent with each other and to be over all, more stream-lined.
