### PR TITLE
Find deps quickfix

### DIFF
--- a/bin/lfe
+++ b/bin/lfe
@@ -118,9 +118,9 @@ done
 # Note that ERL_LIBS will find *either* an ebin subdir *or* lib subdir
 #
 # The following works for rebar and erl.mk
-PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
+PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 # The following works for rebar3
-R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
-LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
+R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
+LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS":"$R3_PROJ_LIBS":"$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec erl "$@"

--- a/bin/lfe
+++ b/bin/lfe
@@ -121,6 +121,6 @@ done
 PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 # The following works for rebar3
 R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
-LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
+LFE_HOME_LIBS=$(find "$HOME"/.lfe/lib -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS":"$R3_PROJ_LIBS":"$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec erl "$@"

--- a/bin/lfescript
+++ b/bin/lfescript
@@ -111,9 +111,9 @@ if [ -z "$shebangs" ] ; then shebangs=$(expr "$line3" : '^;;! *\(.*\)') ; fi
 # Note that ERL_LIBS will find *either* an ebin subdir *or* lib subdir
 #
 # The following works for rebar and erl.mk
-PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
+PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 # The following works for rebar3
-R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
-LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \;)
+R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
+LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS":"$R3_PROJ_LIBS":"$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec "$emulator" +B -boot start_clean "$shebangs" "-noshell" "-run" "lfescript" "start" "$@"

--- a/bin/lfescript
+++ b/bin/lfescript
@@ -114,6 +114,6 @@ if [ -z "$shebangs" ] ; then shebangs=$(expr "$line3" : '^;;! *\(.*\)') ; fi
 PROJ_LIBS=$(find ./deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 # The following works for rebar3
 R3_PROJ_LIBS=$(find ./_build/default/deps -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
-LFE_HOME_LIBS=$(find "$HOME"/.lfe/libs -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
+LFE_HOME_LIBS=$(find "$HOME"/.lfe/lib -maxdepth 1 -mindepth 1 -exec printf "%s:" {} \; 2> /dev/null)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS":"$R3_PROJ_LIBS":"$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec "$emulator" +B -boot start_clean "$shebangs" "-noshell" "-run" "lfescript" "start" "$@"


### PR DESCRIPTION
This includes both the quick-fix for the stderr message when the dirs aren't found as well as using the same dir names as Erlang.

See issue #129 for more details.
