### PR TITLE
Add make {re,un}install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(EBINDIR)/%.beam: $(SRCDIR)/%.lfe
 
 all: compile docs
 
-.PHONY: compile erlc-compile lfec-compile erlc-lfec install docs clean dockerfile
+.PHONY: compile erlc-compile lfec-compile erlc-lfec install reinstall uninstall docs clean dockerfile
 
 ## Compile using rebar if it exists else using make
 compile: maps_opts.mk
@@ -91,6 +91,13 @@ install:
 	ln -s `pwd`/bin/lfe $(DESTBINDIR)
 	ln -s `pwd`/bin/lfec $(DESTBINDIR)
 	ln -s `pwd`/bin/lfescript $(DESTBINDIR)
+
+reinstall: uninstall install
+
+uninstall:
+	rm -f $(DESTBINDIR)/lfe
+	rm -f $(DESTBINDIR)/lfec
+	rm -f $(DESTBINDIR)/lfescript
 
 docs:
 


### PR DESCRIPTION
**I'm making two alternative PRs with the intention of only one getting merged.**
Alternate approach: add -f flag to ln calls (#166)
# 

This one adds `make reinstall` and `make uninstall`, allowing the following to continue to occur:

``` bash
$ make install
ln -s `pwd`/bin/lfe /usr/local/bin
ln: /usr/local/bin/lfe: File exists
make: *** [install] Error 1
```
