### PR TITLE
Add -f flag to ln calls in make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ maps_opts.mk:
 -include maps_opts.mk
 
 install:
-	ln -s `pwd`/bin/lfe $(DESTBINDIR)
-	ln -s `pwd`/bin/lfec $(DESTBINDIR)
-	ln -s `pwd`/bin/lfescript $(DESTBINDIR)
+	ln -sf `pwd`/bin/lfe $(DESTBINDIR)
+	ln -sf `pwd`/bin/lfec $(DESTBINDIR)
+	ln -sf `pwd`/bin/lfescript $(DESTBINDIR)
 
 docs:
 


### PR DESCRIPTION
**I'm making two alternative PRs with the intention of only one getting merged.**
Alternate approach: add {re,un}install targets (#165)
# 

This one adds the `-f` flag to the `ln` calls in `make install`

> If the target file already exists, then unlink it so that the link may occur.

... thereby avoiding the following:

``` bash
$ make install
ln -s `pwd`/bin/lfe /usr/local/bin
ln: /usr/local/bin/lfe: File exists
make: *** [install] Error 1
```
