### PR TITLE
Removed unused PATH variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ INCDIR = include
 DOCDIR = doc
 EMACSDIR = emacs
 
-PATH = $(PATH):$(BINDIR)
 VPATH = $(SRCDIR)
 
 ERLCFLAGS = -W1


### PR DESCRIPTION
This addresses bug #171.

I think the `PATH` variable was added here to assist with a cumbersome problem in building Docker; regardless, there's another way to do it (and nothing else in the `Makefile` was  using the variable).
