### PR TITLE
Add metadata for hex.pm

### DIFF
--- a/src/lfe.app.src
+++ b/src/lfe.app.src
@@ -18,5 +18,10 @@
   {vsn, "0.11.0-dev"},
   {modules, []},
   {registered, []},
-  {applications, [kernel,stdlib,compiler]}
+  {applications, [kernel,stdlib,compiler]},
+  {maintainers, ["Robert Virding"]},
+  {licenses, ["Apache"]},
+  {links, [{"Github", "https://github.com/rvirding/lfe"},
+           {"Main site", "http://lfe.io/"},
+           {"Documentation", "http://docs.lfe.io/"}]}
  ]}.


### PR DESCRIPTION
This enables us to upload proper LFE releases to hex.pm using rebar3.

More information: https://hex.pm/docs/rebar3_publish
