### PR TITLE
Fix travis errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ erl_crash.dump
 /priv/
 /src/lfe_scan.erl
 .rebar/*
+bin/lfeexec
+maps_opts.mk
+ebin/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: erlang
+before_install: echo "#!/usr/bin/env bash" > `which rebar`
+script: make travis
 notifications:
   disabled: true
 otp_release:
-  - R15B02
-  - R15B01
-  - R15B
+  - 18.2
+  - 18.0
+  - 17.5
+  - 17.1
+  - R16B03
+  - R15B03
   - R14B04
-  - R14B03
-  - R14B02

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 # Makefile for LFE
-# This simple Makefile uses rebar (in Unix) or rebar.cmd (in Windows)
-# to compile/clean if it exists, else does it explicitly.
 
 BINDIR = bin
 EBINDIR = ebin
@@ -71,17 +69,8 @@ all: compile docs
 
 .PHONY: compile erlc-compile lfec-compile erlc-lfec emacs install docs clean docker-build docker-push docker
 
-
-
-## Compile using rebar if it exists else using make
 compile: maps_opts.mk
-	if which rebar.cmd > /dev/null; \
-	then ERL_LIBS=.:$$ERL_LIBS rebar.cmd compile; \
-	elif which rebar > /dev/null; \
-	then ERL_LIBS=.:$$ERL_LIBS rebar compile; \
-	else \
-	$(MAKE) $(MFLAGS) erlc-lfec; \
-	fi
+	$(MAKE) $(MFLAGS) erlc-lfec
 
 ## Compile using erlc
 erlc-compile: $(addprefix $(EBINDIR)/, $(EBINS)) $(addprefix $(BINDIR)/, $(BINS))
@@ -108,27 +97,13 @@ install:
 docs:
 
 clean:
-	if which rebar.cmd > /dev/null; \
-	then rebar.cmd clean; \
-	elif which rebar > /dev/null; \
-	then rebar clean; \
-	else rm -rf $(EBINDIR)/*.beam; \
-	fi
-	rm maps_opts.mk
-	rm -rf erl_crash.dump
+	rm -rf $(EBINDIR)/*.beam erl_crash.dump maps_opts.mk
 
 echo:
 	@ echo $(ESRCS)
 	@ echo $(XSRCS)
 	@ echo $(YSRCS)
 	@ echo $(EBINS)
-
-get-deps:
-	if which rebar.cmd > /dev/null; \
-	then rebar.cmd get-deps; \
-	elif which rebar > /dev/null; \
-	then rebar get-deps; \
-	fi
 
 get-version:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ERLC = erlc
 
 LFECFLAGS = -pa ../lfe
 LFEC = $(BINDIR)/lfe $(BINDIR)/lfec
+APP_SRC = lfe.app
 
 LIB=lfe
 
@@ -78,7 +79,10 @@ erlc-compile: $(addprefix $(EBINDIR)/, $(EBINS)) $(addprefix $(BINDIR)/, $(BINS)
 ## Compile using lfec
 lfec-compile: $(addprefix $(EBINDIR)/, $(LBINS))
 
-erlc-lfec: erlc-compile lfec-compile
+$(APP_SRC):
+	cp src/$(APP_SRC).src $(EBINDIR)/$(APP_SRC)
+
+erlc-lfec: erlc-compile lfec-compile $(APP_SRC)
 
 emacs:
 	cd $(EMACSDIR) ; \

--- a/Makefile
+++ b/Makefile
@@ -132,3 +132,8 @@ docker-push:
 	docker push lfex/lfe:latest
 
 docker: docker-build docker-push
+
+travis:
+	@echo "Building for Travis CI ..."
+	@make
+

--- a/bin/lfe
+++ b/bin/lfe
@@ -132,3 +132,4 @@ R3_PROJ_LIBS=$(find_libs "./_build/default/deps"):$(find_libs "./_build/default/
 LFE_HOME_LIBS=$(find_libs "$HOME"/.lfe/lib)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS""$R3_PROJ_LIBS""$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec erl "$@"
+


### PR DESCRIPTION
This branch fixes a few small errors that were cropping up on Travis CI; the major fixes actually came from @rvirding's fixes in eccdfcd8333604f2cb38bec86452d2b885d925a4.

Note that this branch had to inherit from the `drop-rebar` branch, since that helped fix a series of issues on Travis CI.

As such, it should be merged after the `drop-rebar` branch. I can rebase after that, if needed.

Fixes #199.
