### PR TITLE
Update Makefile and doc/user_guide.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,14 +173,16 @@ docs-txt: docs-man \
 	$(addprefix $(DOCDIR)/, $(TXT7S))
 	@mv $(DOCDIR)/lfe_guide.txt $(DOCDIR)/user_guide.txt
 
+$(DOCDIR)/%.txt: export GROFF_NO_SGR=1
+
 $(DOCDIR)/%.txt: $(MANDIR)/%.1
-	groff -t -e -mandoc -T utf8 $< | col -bx > $@
+	groff -t -e -mandoc -Tutf8 -Kutf8 $< | col -bx > $@
 
 $(DOCDIR)/%.txt: $(MANDIR)/%.3
-	groff -t -e -mandoc -T utf8 $< | col -bx > $@
+	groff -t -e -mandoc -Tutf8 -Kutf8 $< | col -bx > $@
 
 $(DOCDIR)/%.txt: $(MANDIR)/%.7
-	groff -t -e -mandoc -T utf8 $< | col -bx > $@
+	groff -t -e -mandoc -Tutf8 -Kutf8 $< | col -bx > $@
 
 $(PDFDIR):
 	@mkdir -p $(PDFDIR)

--- a/doc/user_guide.txt
+++ b/doc/user_guide.txt
@@ -43,7 +43,7 @@ LITERALS AND SPECIAL SYNTACTIC RULES
        · Character  notation (the value is the Unicode code point of the char‐
          acter):
 
-           #\a #\$ #\Ã¤ #\ð
+           #\a #\$ #\ä #\🐭
 
        · Character notation with the value in hexadecimal:
 
@@ -91,7 +91,7 @@ LITERALS AND SPECIAL SYNTACTIC RULES
        "61;62;63;" is a complicated way of writing "abc".  This can be  conve‐
        nient when writing Unicode letters not easily typeable or viewable with
        regular fonts.  E.g.  "Cat: 1f639;" might be easier to type  (and  view
-       on output devices without a Unicode font) than "Cat: ð¹".
+       on output devices without a Unicode font) than "Cat: 😹".
 
    Binary Strings
        Binary strings are just like list strings but they are represented dif‐
@@ -137,8 +137,8 @@ LITERALS AND SPECIAL SYNTACTIC RULES
               #B(0 0 0 42 42 0 0 0)
               > #B((1.23 float) (1.23 (size 32) float) (1.23 (size 64) float))
               #B(63 243 174 20 122 225 71 174 63 157 112 164 63 243 174 20 122 225 71 174)
-              > #B((#"a" binary) (#"b" binary)) â¨ #"ab"
-              #B("Cat:" #\ (128569 utf-8)) â¨ #"Cat: ð¹"
+              > #B((#"a" binary) (#"b" binary)) ⇨ #"ab"
+              #B("Cat:" #\ (128569 utf-8)) ⇨ #"Cat: 😹"
 
        Learn more about "segments" of binary data e.g.   in  "Learn  You  Some
        Erlang    (http://learnyousomeerlang.com/starting-out-for-real#bit-syn‐
@@ -178,11 +178,11 @@ LITERALS AND SPECIAL SYNTACTIC RULES
               !, #, $, %, &, ', *, +, ,, -, ., /, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, :, <,
               =, >, ?, @, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T,
               U, V, W, X, Y, Z, \, ^, _, , a, b, c, d, e, f, g, h, i, j, k, l, m, n,
-              o, p, q, r, s, t, u, v, w, x, y, z, |, ~, \  , Â¡, Â¢, Â£, Â¤, Â¥, Â¦, Â§, Â¨,
-              Â©, Âª, Â«, Â¬, \Â, Â®, Â¯, Â°, Â±, Â², Â³, Â´, Âµ, Â¶, Â·, Â¸, Â¹, Âº, Â», Â¼, Â½, Â¾, Â¿, Ã,
-              Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã,
-              Ã, Ã, Ã, Ã, Ã, Ã, Ã, Ã , Ã¡, Ã¢, Ã£, Ã¤, Ã¥, Ã¦, Ã§, Ã¨, Ã©, Ãª, Ã«, Ã¬, Ã, Ã®, Ã¯, Ã°,
-              Ã±, Ã², Ã³, Ã´, Ãµ, Ã¶, Ã·, Ã¸, Ã¹, Ãº, Ã», Ã¼, Ã½, Ã¾, Ã¿
+              o, p, q, r, s, t, u, v, w, x, y, z, |, ~, \  , ¡, ¢, £, ¤, ¥, ¦, §, ¨,
+              ©, ª, «, ¬, \, ®, ¯, °, ±, ², ³, ´, µ, ¶, ·, ¸, ¹, º, », ¼, ½, ¾, ¿, À,
+              Á, Â, Ã, Ä, Å, Æ, Ç, È, É, Ê, Ë, Ì, Í, Î, Ï, Ð, Ñ, Ò, Ó, Ô, Õ, Ö, ×, Ø,
+              Ù, Ú, Û, Ü, Ý, Þ, ß, à, á, â, ã, ä, å, æ, ç, è, é, ê, ë, ì, í, î, ï, ð,
+              ñ, ò, ó, ô, õ, ö, ÷, ø, ù, ú, û, ü, ý, þ, ÿ
 
        (This is basically all of the latin-1  character  set  without  control
        character,  whitespace,  the  various brackets, double quotes and semi‐
@@ -191,7 +191,7 @@ LITERALS AND SPECIAL SYNTACTIC RULES
        Of these, only |, \', ', ,, and # may not be the first character of the
        symbol's name (but they are allowed as subsequent letters).
 
-       I.e.  these are all legal symbols: foo, foo, Âµ#, Â±1, 451Â°F.
+       I.e.  these are all legal symbols: foo, foo, µ#, ±1, 451°F.
 
        Symbols  can be explicitly constructed by wrapping their name in verti‐
        cal bars, e.g.  |foo|, |symbol name with spaces|.   In  this  case  the


### PR DESCRIPTION
Fix some encoding-related errors by adding `GROFF_NO_SGR=1`
to the relevant make targets and updating the `groff` calls
to use the `-K` flag to specify UTF-8 as the input encoding.

N.B. I'm using GNU groff version 1.22.3.
Older versions don't seem to support `-K`.

To install groff 1.22.3 on OS X:

``` fish
$ brew tap homebrew/dupes
$ brew install homebrew/dupes/groff
```

http://stackoverflow.com/a/24969648/1793234

---

**Update**: This [change log entry](http://git.savannah.gnu.org/cgit/groff.git/tree/ChangeLog.120#n2873) leads me to believe the `-K` option was added in version 1.20.
