### PR TITLE
Make DESTBINDIR configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ EMACSRCS = $(notdir $(wildcard $(EMACSDIR)/*.el))
 ELCS = $(EMACSRCS:.el=.elc)
 
 ## Where we install links to the LFE binaries.
-DESTBINDIR = $(PREFIX)$(shell dirname `which erl` 2> /dev/null || echo "/usr/local/bin" )
+DESTBINDIR ?= $(PREFIX)$(shell dirname `which erl` 2> /dev/null || echo "/usr/local/bin" )
 
 .SUFFIXES: .erl .beam
 


### PR DESCRIPTION
This single character change enables `$DESTBINDIR` to be set by the user.

I use [Nix](http://nixos.org/nixpkgs/) to [manage Erlang installations](https://twitter.com/yurrriq/status/716885338493288449), which results in my inability to use the default `$DESTBINDIR`, for some reason, and thus `make install` fails.

With this change, the following works for me in fish shell:

``` fish
env DESTBINDIR=/usr/local/bin make install
```

This shouldn't have any negative consequences for "normal" users and might be helpful to others as well.
