### PR TITLE
Fix prop_lfe_doc and lfedoc

### DIFF
--- a/bin/lfedoc
+++ b/bin/lfedoc
@@ -113,13 +113,11 @@
      (case (ldoc-chunk beam)
        (`#(ok ,(match-lfe_docs_v1 docs docs moduledoc moduledoc))
         (let ((hrule      (lists:duplicate 70 #\-))
-              (moduledoc* (if (=:= #"" moduledoc)
+              (moduledoc* (if (=:= [] moduledoc)
                             #""
-                            (list #"  "
-                                  (lists:map
-                                    (lambda (line) (list line #"\n"))
-                                    (binary:split moduledoc
-                                                  #"\n" '[global]))))))
+                            (lists:map
+                              (lambda (line) (list #"  " line #"\n"))
+                              moduledoc))))
           (lfe_io:format "~p\n~s~s\n\n" (list name moduledoc* hrule)))
         (lists:foreach #'print-doc/1 docs)
         (print-ldocs mods))

--- a/dev/example.lfe
+++ b/dev/example.lfe
@@ -1,7 +1,7 @@
 (defmodule example
-  (doc "This is an example module.")
-  (export all)
-  (export-macro add varargs forty-two?))
+  "This is an example module."
+  (export (matchfun 3))
+  (export-macro add varargs forty-two? tricky))
 
 (defmacro add (x y)
   "Add `x` and `y`."
@@ -19,13 +19,15 @@
 
 (defmacro tricky
   "This is a tricky varargs macro."
-  ([x]       'one)
-  ([x y]     'two)
-  ([x y . z] 'many))
+  (`(,x)         'one)
+  (`(,x ,y)      'two)
+  (`(,x ,y . ,z) 'many))
 
-(defun subtract (x y)
+(define-function subtract
   "Subtract `y` from `x`."
-  (- x y))
+  (lambda (x y) (- x y)))
+
+(extend-module "" (export (subtract 2)))
 
 (defun matchfun
   "This is a function with pattern clauses."
@@ -34,10 +36,12 @@
   ([x y z] (when (=:= x y) (=:= y z)) 'eq)
   ([_ _ _]                            'idk))
 
+
 (defmodule another-example
-  ;; Deliberately no doc here.
-  (export all))
+  "")
 
 (defun divmod (n d)
   ;; Deliberately no docstring here.
   (tuple (div n d) (rem n d)))
+
+(extend-module "This is another example." (export (divmod 2)))

--- a/test/prop_lfe_doc.erl
+++ b/test/prop_lfe_doc.erl
@@ -34,17 +34,17 @@ prop_define_lambda() -> ?FORALL(Def, define_lambda(), validate(Def)).
 
 prop_define_match() -> ?FORALL(Def, define_match(), validate(Def)).
 
-validate({['define-function',Name,[lambda,Args|_],_],_}=Def) ->
+validate({['define-function',Name,_Doc,[lambda,Args|_]],_}=Def) ->
     do_validate({Name,arity([Args])}, Def);
-validate({['define-function',Name,['match-lambda',[Pat|_]|_],_],_}=Def) ->
+validate({['define-function',Name,_Doc,['match-lambda',[Pat|_]|_]],_}=Def) ->
     do_validate({Name,arity([Pat])}, Def);
-validate({['define-macro',Name,['match-lambda'|_],_],_}=Def) ->
+validate({['define-macro',Name,_Doc,['match-lambda'|_]],_}=Def) ->
     do_validate(Name, Def).
 
-do_validate(Name,{[Define,_,_,DocStr],Line}=Def) ->
-    Type  = define_to_type(Define),
+do_validate(Name,{[Define,_Name,DocStr,_Lambda],Line}=Def) ->
+    Type = define_to_type(Define),
     case module([Def], #cinfo{}) of
-        {ok,[#doc{type=Type,name=Name,doc=Doc,line=Line}]} ->
+        {ok,{[],[#doc{type=Type,name=Name,doc=Doc,line=Line}=Res]}} ->
             string_to_binary(DocStr) =:= Doc;
         _ ->
             false
@@ -58,10 +58,10 @@ define_to_type('define-macro')    -> macro.
 %%% Definition shapes
 %%%===================================================================
 
-define_lambda() -> {['define-function',atom1(),lambda(),docstring()],line()}.
+define_lambda() -> {['define-function',atom1(),docstring(),lambda()],line()}.
 
 define_match() ->
-    ?LET(D, define(), {[D,atom1(),'match-lambda'(D),docstring()],line()}).
+    ?LET(D, define(), {[D,atom1(),docstring(),'match-lambda'(D)],line()}).
 
 
 %%%===================================================================


### PR DESCRIPTION
- Fix property tests for rearranged internal forms
- Move `example.lfe` to `dev/` and fix `bin/lfedoc`
  
  Also fix some mistakes in `example.lfe` and use a `define-function`
  once for good measure.
