### PR TITLE
Update bin paths in rebar3 ct pre_hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: true
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
-env: PATH=$PATH:.:./bin
+env: PATH=$PATH:.
 script: make travis
 notifications:
   disabled: true

--- a/rebar.config
+++ b/rebar.config
@@ -6,10 +6,10 @@
 
 {pre_hooks, [{"(linux|darwin|solaris)", ct, "make"},
              {"(linux|darwin|solaris)", ct,
-              "./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"},
+              "./bin/lfe ./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"},
              {"(freebsd|netbsd|openbsd)", ct, "gmake"},
              {"(freebsd|netbsd|openbsd)", ct,
-              "./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"}
+              "./bin/lfe ./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"}
              %% TODO: Test this on a win32 box
              %% {"win32", ct, "make"},
              %% {"win32", ct,


### PR DESCRIPTION
Unless prefixed with `./bin/lfe`, `./bin/lfec` will use the version
of LFE installed on the system, which in my case is often incorrect.

Close #251
