### PR TITLE
Update rebar.config, .travis.yml and bin/lfe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: true
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
-env: PATH=$PATH:.:./bin
+env: PATH=$PATH:.
 script: make travis
 notifications:
   disabled: true

--- a/bin/lfe
+++ b/bin/lfe
@@ -128,8 +128,13 @@ find_libs () {
 # The following works for rebar and erl.mk
 PROJ_LIBS=$(find_libs "./deps")
 # The following works for rebar3
-R3_PROJ_LIBS=$(find_libs "./_build/default/deps"):$(find_libs "./_build/default/lib")
+if [ -d "$REBAR_DEPS_DIR" ]; then
+    # Use $REBAR_DEPS_DIR if set...
+    R3_PROJ_LIBS=$(find_libs "$REBAR_DEPS_DIR")
+else
+    # ... otherwise provide a sensible default
+    R3_PROJ_LIBS=$(find_libs "./_build/default/deps"):$(find_libs "./_build/default/lib")
+fi
 LFE_HOME_LIBS=$(find_libs "$HOME"/.lfe/lib)
 ALL_LIBS="$LFE_ROOTDIR":"$ERL_LIBS":"$PROJ_LIBS""$R3_PROJ_LIBS""$LFE_HOME_LIBS"
 ERL_LIBS="$ALL_LIBS" exec erl "$@"
-

--- a/rebar.config
+++ b/rebar.config
@@ -4,14 +4,16 @@
 
 {profiles, [{test, [{deps, [proper]}]}]}.
 
-{pre_hooks, [{"(linux|darwin|solaris)", ct, "make"},
-             {"(linux|darwin|solaris)", ct,
-              "./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"},
-             {"(freebsd|netbsd|openbsd)", ct, "gmake"},
+{pre_hooks, [{"(linux|darwin|solaris)", ct,
+              "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/test test/*_SUITE.lfe"},
              {"(freebsd|netbsd|openbsd)", ct,
-              "./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"}
+              "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/test test/*_SUITE.lfe"}
              %% TODO: Test this on a win32 box
-             %% {"win32", ct, "make"},
-             %% {"win32", ct,
-             %%  "./bin/lfec -o ./_build/test/lib/lfe/test test/*_SUITE.lfe"}
+             %%  {"win32", ct,
+             %%   "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/test test/*_SUITE.lfe"}
             ]}.
+
+{post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", compile,
+               "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/ebin src/*.lfe"}
+              %% TODO: equivalent win32 hook
+             ]}.


### PR DESCRIPTION
Unless prefixed with `./bin/lfe`, `./bin/lfec` will use the version of
`lfe` installed on the system, which in my case is often incorrect.

Add a `compile` `post_hook` to compile `src/*.lfe` and output the beams
to the correct directory (as per `$REBAR_DEPS_DIR`). Remove the
redundant `make` in the `ct` `pre_hooks` and use `$REBAR_DEPS_DIR`
instead of the hard-coded `_build/test/lib`.

Remove `./bin` from `$PATH` in `.travis.yml` to avoid similar confusion
in the future.

Use `$REBAR_DEPS_DIR` in `bin/lfe` when set, otherwise fall back to
`./_build/default/{deps,lib}` as before.

Close #251

---

@rvirding: This version is more robust than #252 and now `rebar3 ct` works without running `make compile`, thereby avoiding redundant compilation. `bin/lfe` is also more robust, as it uses `$REBAR_DEPS_DIR` when available. If that's not set, it'll behave exactly as before.
