### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ with LFE, be sure to read the
 Files with more technical details:
 
 * [lfescript.txt](doc/lfescript.txt)
-* [lfe_shell.txt](doc/lfe_shell.txt)
+* [lfe_shell.txt](doc/lfe.txt)
 * [lfe_macro.txt](doc/lfe_macro.txt)
 * [lfe_lib.txt](doc/lfe_lib.txt)
 * [lfe_io.txt](doc/lfe_io.txt)


### PR DESCRIPTION
The link pointing to the previous doc/lfe_shell.txt became broken
when the name of the file was changed to doc/lfe.txt - this fixes
the link in the top-level README file.

HTH
