### PR TITLE
Ensure cl and clj are in lfe.app

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,13 +11,11 @@
              {"(linux|darwin|solaris|freebsd|netbsd|openbsd)", eunit,
               "bin/lfe bin/lfec"
               " -o $REBAR_DEPS_DIR/lfe/ebin"
-              " test/clj-tests.lfe"}
+              " test/clj-tests.lfe"},
              %% TODO: Test this on a win32 box
              %%  {"win32", ct,
              %%   "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/test test/*_SUITE.lfe"}
+             {"(linux|darwin|solaris|freebsd|netbsd|openbsd)", app_compile,
+              "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/ebin src/*.lfe"}
+             %% TODO: equivalent win32 hook
             ]}.
-
-{post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", compile,
-               "bin/lfe bin/lfec -o $REBAR_DEPS_DIR/lfe/ebin src/*.lfe"}
-              %% TODO: equivalent win32 hook
-             ]}.


### PR DESCRIPTION
Compile `src/cl.lfe` and `src/clj.lfe` as a `pre_hook` to `app_compile` instead of a `post_hook` to `compile` to ensure they end up in `lfe.app`'s `modules`.

Without this patch, I can't use `lfe` (well, namely the `clj` or `cl` modules) in a release.

Many thanks to @talentdeficit and @tsloughter!
