### PR TITLE
Add lazy-seq/1 to support finite lazy sequences

### DIFF
--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -500,12 +500,10 @@ EXPORTS
        as the tail.  The result can be treated as a (possibly  infinite)  lazy
        list, which only computes subseqeuent values as needed.
 
-       (lazy-seq f)
+       (lazy-seq seq)
 
-       (lazy-seq lst)
-
-       Return  a  lazy sequence (possibly infinite) from given lazy sequence f
-       or finite lazy sequence from given list lst.  Lazy sequence is  treated
+       Return a lazy sequence (possibly infinite) from given lazy sequence seq
+       or finite lazy sequence from given list seq.  Lazy sequence is  treated
        as finite if at any iteration it produces empty list instead of data as
        its head and nullary function for next iteration as its tail.
 

--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -500,6 +500,15 @@ EXPORTS
        as the tail.  The result can be treated as a (possibly  infinite)  lazy
        list, which only computes subseqeuent values as needed.
 
+       (lazy-seq f)
+
+       (lazy-seq lst)
+
+       Return  a  lazy sequence (possibly infinite) from given lazy sequence f
+       or finite lazy sequence from given list lst.  Lazy sequence is  treated
+       as finite if at any iteration it produces empty list instead of data as
+       its head and nullary function for next iteration as its tail.
+
        (cycle lst)
 
        Return a lazy infinite sequence with all elements from a given list lst
@@ -517,7 +526,7 @@ EXPORTS
 
        (range start step)
 
-       Return a lazy list of integers, starting with start and  increasing  by
+       Return  a  lazy list of integers, starting with start and increasing by
        step.  Equivalent to (next #'+/2 start step).  See also: next/3.
 
        (drop n lst)
@@ -532,7 +541,7 @@ EXPORTS
        (take 'all lst)
 
        Given a (possibly lazy) list lst, return a list of the first n elements
-       of  lst,  or  all elements if there are fewer than n.  If n is the atom
+       of lst, or all elements if there are fewer than n.  If n  is  the  atom
        all and lst is a "normal" list, return lst.
 
        (split-at n lst)
@@ -551,7 +560,7 @@ EXPORTS
 
        Return a list of lists of n items each, at offsets step apart.  Use the
        elements of pad as necessary to complete the last partition up to n el‐
-       ements.  In case there are not enough padding elements, return a  pari‐
+       ements.   In case there are not enough padding elements, return a pari‐
        tion with less than n items.
 
        (partition-all n lst)
@@ -560,7 +569,7 @@ EXPORTS
 
        (partition-all n step lst)
 
-       Return  a list of lists like partition/3, possibly including partitions
+       Return a list of lists like partition/3, possibly including  partitions
        with fewer than n elements at the end.
 
        (interleave list-1 list-2)
@@ -573,8 +582,8 @@ EXPORTS
 
        (get-in data keys not-found)
 
-       Return the value in a nested associative structure,  where  keys  is  a
-       list  of keys or list indices.  Return the atom not-found if the key is
+       Return  the  value  in  a nested associative structure, where keys is a
+       list of keys or list indices.  Return the atom not-found if the key  is
        not present or index is out of bounds, or the not-found value.
 
        (reduce func (cons head tail))
@@ -606,7 +615,7 @@ EXPORTS
 
        (constantly x)
 
-       Return a unary function that returns x.  N.B.  This is  like  Haskell's
+       Return  a  unary function that returns x.  N.B.  This is like Haskell's
        const rather than Clojure's constantly.
 
        (inc x)

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -602,6 +602,16 @@ as the head and a nullary function,
 The result can be treated as a (possibly infinite) lazy list, which only
 computes subseqeuent values as needed.
 .PP
+\f[B](lazy\-seq f)\f[]
+.PP
+\f[B](lazy\-seq lst)\f[]
+.PP
+Return a lazy sequence (possibly infinite) from given lazy sequence
+\f[C]f\f[] or finite lazy sequence from given list \f[C]lst\f[].
+Lazy sequence is treated as finite if at any iteration it produces empty
+list instead of data as its head and nullary function for next iteration
+as its tail.
+.PP
 \f[B](cycle lst)\f[]
 .PP
 Return a lazy infinite sequence with all elements from a given list

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -602,12 +602,10 @@ as the head and a nullary function,
 The result can be treated as a (possibly infinite) lazy list, which only
 computes subseqeuent values as needed.
 .PP
-\f[B](lazy\-seq f)\f[]
-.PP
-\f[B](lazy\-seq lst)\f[]
+\f[B](lazy\-seq seq)\f[]
 .PP
 Return a lazy sequence (possibly infinite) from given lazy sequence
-\f[C]f\f[] or finite lazy sequence from given list \f[C]lst\f[].
+\f[C]seq\f[] or finite lazy sequence from given list \f[C]seq\f[].
 Lazy sequence is treated as finite if at any iteration it produces empty
 list instead of data as its head and nullary function for next iteration
 as its tail.

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -551,6 +551,15 @@ a nullary function, `(next func (funcall func start step) step)` as the tail.
 The result can be treated as a (possibly infinite) lazy list, which only
 computes subseqeuent values as needed.
 
+**(lazy-seq f)**
+
+**(lazy-seq lst)**
+
+Return a lazy sequence (possibly infinite) from given lazy sequence `f`
+or finite lazy sequence from given list `lst`. Lazy sequence is treated as
+finite if at any iteration it produces empty list instead of data as its
+head and nullary function for next iteration as its tail.
+
 **(cycle lst)**
 
 Return a lazy infinite sequence with all elements from a given list `lst` or

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -551,12 +551,10 @@ a nullary function, `(next func (funcall func start step) step)` as the tail.
 The result can be treated as a (possibly infinite) lazy list, which only
 computes subseqeuent values as needed.
 
-**(lazy-seq f)**
+**(lazy-seq seq)**
 
-**(lazy-seq lst)**
-
-Return a lazy sequence (possibly infinite) from given lazy sequence `f`
-or finite lazy sequence from given list `lst`. Lazy sequence is treated as
+Return a lazy sequence (possibly infinite) from given lazy sequence `seq`
+or finite lazy sequence from given list `seq`. Lazy sequence is treated as
 finite if at any iteration it produces empty list instead of data as its
 head and nullary function for next iteration as its tail.
 

--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -671,8 +671,8 @@
 (defn- -drop
   ([_ ()] ())
   ([0 data] data)
-  ([n `(,_ . ,tail)]
-   (when (function? tail)) (-drop (dec n) (funcall tail))))
+  ([n `(,_ . ,tail)] (when (function? tail))
+   (-drop (dec n) (funcall tail))))
 
 (defn- -take
   ([_ acc ()] (lists:reverse acc))

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -544,6 +544,41 @@
                                          ([3 _] 4)
                                          ([4 _] (error 'overzealous-take)))))))
 
+(deftest lazy-seq-and-take-and-drop
+  (are* [x y] (ok? (is-match x y))
+
+        ()
+        (clj:lazy-seq ())
+
+        ()
+        (clj:take 1 (clj:lazy-seq ()))
+
+        '(1 2)
+        (clj:take 2 (clj:lazy-seq '(1 2 3)))
+
+        '(1 2 3)
+        (clj:take 3 (clj:lazy-seq '(1 2 3)))
+
+        '(1 2 3)
+        (clj:take 4 (clj:lazy-seq '(1 2 3))))
+
+  (are* [x y] (ok? (is-match x y))
+
+        ()
+        (clj:take 1 (clj:drop 1 (clj:lazy-seq ())))
+
+        ()
+        (clj:take 1 (clj:drop 1 (clj:lazy-seq '(1))))
+
+        ()
+        (clj:take 1 (clj:drop 4 (clj:lazy-seq '(1 2 3))))
+
+        '(2 3)
+        (clj:take 2 (clj:drop 1 (clj:lazy-seq '(1 2 3))))
+
+        '(2 3)
+        (clj:take 2 (clj:drop 1 (clj:range 1)))))
+
 (deftest cycle-and-take
   (are* [x y] (ok? (is-match x y))
 

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -609,7 +609,21 @@
         (clj:take 4 (clj:cycle (clj:range 3)))
 
         '(1 2 3 1)
-        (clj:take 4 (clj:cycle (clj:cycle '(1 2 3))))))
+        (clj:take 4 (clj:cycle (clj:cycle '(1 2 3)))))
+
+  (are* [x y] (ok? (is-match x y))
+
+        ()
+        (clj:cycle (clj:lazy-seq ()))
+
+        '(1 1 1)
+        (clj:take 3 (clj:cycle (clj:lazy-seq '(1))))
+
+        '(1 2 3 1 2 3 1)
+        (clj:take 7 (clj:cycle (clj:lazy-seq '(1 2 3))))
+
+        '(2 3 2 3 2)
+        (clj:take 5 (clj:cycle (clj:drop 1 (clj:lazy-seq '(1 2 3)))))))
 
 (deftest range
   (are* [x y] (ok? (is-match x y))


### PR DESCRIPTION
#289 Implement lazy sequences

`lazy-seq/1` takes a list to generate finite lazy sequence or another lazy sequence that passes as is. Lazy sequence is treated as finite if at any iteration it produces empty list instead of data as its head and nullary function for next iteration as its tail.

`drop/2` and `take/2` are modified to handle this behaviour. Commits for tests and documentation will follow today if anything is ok.

/CC @yurrriq @rvirding 
