### PR TITLE
Fix parallelized builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ compile: comp_opts.mk
 erlc-compile: $(addprefix $(EBINDIR)/, $(EBINS)) $(addprefix $(BINDIR)/, $(BINS))
 
 ## Compile using lfec
-lfec-compile: $(addprefix $(EBINDIR)/, $(LBINS))
+lfec-compile: erlc-lfec $(addprefix $(EBINDIR)/, $(LBINS))
 
 $(EBINDIR)/$(APP_DEF): $(SRCDIR)/$(APP_DEF).src
 	cp $(SRCDIR)/$(APP_DEF).src $(EBINDIR)/$(APP_DEF)
 
-erlc-lfec: erlc-compile lfec-compile $(EBINDIR)/$(APP_DEF)
+erlc-lfec: erlc-compile $(EBINDIR)/$(APP_DEF)
 
 emacs:
 	cd $(EMACSDIR) ; \


### PR DESCRIPTION
erlc-lfec must go before lfec-compile not vice versa.

Prevents

```
cp src/lfe.app.src ebin/lfe.app
erlc -I include -o ebin -DERLANG_VERSION=\"19.1\" -DHAS_MAPS=true -DHAS_FULL_KEYS=true -DNEW_REC_CORE=true -DNEW_RAND=true -W1 src/lfe_scan.erl

=ERROR REPORT==== 18-Oct-2016::23:33:15 ===
Error in process <0.49.0> with exit value:
{undef,[{lfe_scan,start_symbol_char,"u",[]},
        {lfe_io_write,quote_symbol,2,
                      [{file,"src/lfe_io_write.erl"},{line,127}]},
        {lfe_io_write,symbol,1,[{file,"src/lfe_io_write.erl"},{line,59}]},
        {lfe_lib,format_exception,6,[{file,"src/lfe_lib.erl"},{line,408}]},
        {lfe_init,run_script,1,[{file,"src/lfe_init.erl"},{line,74}]}]}

=ERROR REPORT==== 18-Oct-2016::23:33:15 ===
Error in process <0.49.0> with exit value:
{undef,[{lfe_scan,start_symbol_char,"u",[]},
        {lfe_io_write,quote_symbol,2,
                      [{file,"src/lfe_io_write.erl"},{line,127}]},
        {lfe_io_write,symbol,1,[{file,"src/lfe_io_write.erl"},{line,59}]},
        {lfe_lib,format_exception,6,[{file,"src/lfe_lib.erl"},{line,408}]},
        {lfe_init,run_script,1,[{file,"src/lfe_init.erl"},{line,74}]}]}
```
