### PR TITLE
Updated dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,23 @@ FROM debian:latest
 MAINTAINER LFE Maintainers <maintainers@lfe.io>
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
     apt-utils \
-    build-essential \
+    build-essential
+RUN apt-get install -y --no-install-recommends \
     ca-certificates \
     libcurl4-openssl-dev \
     curl \
     wget \
     git
+RUN apt-get install -y --no-install-recommends \
+    libsctp1 libsctp-dev lksctp-tools
+RUN apt-get install -y --no-install-recommends \
+    pandoc
 
 ENV ERLANG_DEB1 erlang-solutions_1.0_all.deb
-ENV ERLANG_DEB2 esl-erlang_18.3-1~debian~jessie_amd64.deb
+ENV ERLANG_DEB2 esl-erlang_19.1.3-1~debian~jessie_amd64.deb
 ENV ERLANG_HOST https://packages.erlang-solutions.com
 ENV ERLANG_PATH erlang/esl-erlang/FLAVOUR_1_general
 RUN curl -L -O $ERLANG_HOST/$ERLANG_DEB1


### PR DESCRIPTION
This was used to update the lfex/lfe and lfex/lfe-docs Dockerhub images. In
addition to some minor cleanup, it did the following:
- Upgraded the dockerfile to use Erlang 19.1
- Upgraded LFE to use the latest dev version, 1.3-dev
