### PR TITLE
Add version functions to LFE

### DIFF
--- a/doc/lfe.txt
+++ b/doc/lfe.txt
@@ -110,6 +110,13 @@ BUILT-IN SHELL FUNCTIONS
 
        Print information about the registered processes in the system.
 
+       (version)
+
+       Return a data structure of current version information.
+
+       (version App)
+
+
 BUILT-IN SHELL COMMANDS
        These are special forms which are only recognised at the  top-level  in
        shell input.  The cannot be redefined.
@@ -144,6 +151,13 @@ BUILT-IN SHELL COMMANDS
        Revert back to the state before the last slurp  removing  all  function
        and macro definitions both in the slurped file and defined in the shell
        since then.
+
+
+       (run File)
+
+       Execute all the shell commands in File.  All defined  variables,  func‐
+       tions  and  macros will be saved in the environment if there are no er‐
+       rors.
 
 SHELL FUNCTIONS AND MACROS
        Functions and macros can be defined in the shell.  These will  only  be

--- a/doc/lfe_guide.txt
+++ b/doc/lfe_guide.txt
@@ -1109,6 +1109,137 @@ Predefined LFE functions
 
               (include‐lib "lfe/include/clj.lfe")
 
+   Supplemental Common Lisp Functions
+       LFE provides the module cl which contains the following functions which
+       closely mirror functions defined in the Common  Lisp  Hyperspec.   Note
+       that  the following functions use zero−based indices, like Common Lisp.
+       A major difference is that the boolean values are  the  LFE  'true  and
+       'false.   Otherwise  the  definitions closely follow the CL definitions
+       and won't be documented here.
+
+              cl:make−lfe−bool cl−value
+              cl:make−cl−bool lfe−bool
+
+              cl:mapcar  function  list
+              cl:maplist  function  list
+              cl:mapc  function  list
+              cl:mapl  function  list
+
+              cl:symbol−plist  symbol
+              cl:symbol−name  symbol
+              cl:get  symbol  pname
+              cl:get  symbol  pname  default
+              cl:getl  symbol  pname−list
+              cl:putprop  symbol  value  pname
+              cl:remprop  symbol  pname
+
+              cl:getf  plist  pname
+              cl:getf  plist  pname  default
+              cl:putf  plist  value  pname            This does not exist in CL
+              cl:remf  plist  pname
+              cl:get−properties  plist  pname−list
+
+              cl:elt  index  sequence
+              cl:length  sequence
+              cl:reverse  sequence
+              cl:some  predicate  sequence
+              cl:every  predicate  sequence
+              cl:notany  predicate  sequence
+              cl:notevery  predicate  sequence
+              cl:reduce  function  sequence
+              cl:reduce  function  sequence  'initial−value  x
+              cl:reduce  function  sequence  'from−end  'true
+              cl:reduce  function  sequence  'initial−value  x  'from−end  'true
+
+              cl:remove  item  sequence
+              cl:remove−if  predicate  sequence
+              cl:remove−if−not  predicate  sequence
+              cl:remove−duplicates  sequence
+
+              cl:find  item  sequence
+              cl:find−if  predicate  sequence
+              cl:find−if−not  predicate  sequence
+              cl:find−duplicates  sequence
+              cl:position  item  sequence
+              cl:position−if  predicate  sequence
+              cl:position−if−not  predicate  sequence
+              cl:position−duplicates  sequence
+              cl:count  item  sequence
+              cl:count−if  predicate  sequence
+              cl:count−if−not  predicate  sequence
+              cl:count−duplicates  sequence
+
+              cl:car  list
+              cl:first  list
+              cl:cdr  list
+              cl:rest  list
+              cl:nth  index  list
+              cl:nthcdr  index  list
+              cl:last  list
+              cl:butlast  list
+
+              cl:subst  new  old  tree
+              cl:subst−if  new  test  tree
+              cl:subst−if−not  new  test  tree
+              cl:sublis  alist  tree
+
+              cl:member  item  list
+              cl:member−if  predicate  list
+              cl:member−if−not  predicate  list
+              cl:adjoin  item  list
+              cl:union  list  list
+              cl:intersection  list  list
+              cl:set−difference  list  list
+              cl:set−exclusive−or  list  list
+              cl:subsetp  list  list
+
+              cl:acons  key  data  alist
+              cl:pairlis  list  list
+              cl:pairlis  list  list  alist
+              cl:assoc  key  alist
+              cl:assoc−if  predicate  alost
+              cl:assoc−if−not  predicate  alost
+              cl:rassoc  key  alist
+              cl:rassoc−if  predicate  alost
+              cl:rassoc−if−not  predicate  alost
+
+              cl:type−of  object
+              cl:coerce  object  type
+
+       Furthmore, there is an include file which developers may which to  uti‐
+       lize  in  their LFE programs: (include−lib "lfe/include/cl.lfe").  Cur‐
+       rently this offers Common Lisp predicates, but may include other useful
+       macros and functions in the future.  The provided predicate macros wrap
+       the various is_* Erlang functions; since these are expanded at  compile
+       time, they are usable in guards.  The include the following:
+
+              (alivep x)
+              (atomp x)
+              (binaryp x)
+              (bitstringp x)
+              (boolp x) and (booleanp x)
+              (builtinp x)
+              (floatp x)
+              (funcp x) and (functionp x)
+              (intp x) and (integerp x)
+              (listp x)
+              (mapp x)
+              (numberp x)
+              (pidp x)
+              (process−alive−p x)
+              (recordp x tag)
+              (recordp x tag size)
+              (refp x) and (referencep x)
+              (tuplep x)
+
+   Utility and System Information Functions
+       lfe_system_info:app_version  atom  lfe_system_info:os_versions lfe_sys‐
+       tem_info:core_versions   lfe_system_info:tool_versions   lfe_system_in‐
+       fo:version lfe_system_info:version atom
+
+       Note  that an alias is provided for the last two as version, accessible
+       both from LFE modules and the LFE REPL.
+
 Notes
        · NYI ‐ Not Yet Implemented
 

--- a/doc/lfe_guide.txt
+++ b/doc/lfe_guide.txt
@@ -1233,9 +1233,12 @@ Predefined LFE functions
               (tuplep x)
 
    Utility and System Information Functions
-       lfe_system_info:app_version  atom  lfe_system_info:os_versions lfe_sys‐
-       tem_info:core_versions   lfe_system_info:tool_versions   lfe_system_in‐
-       fo:version lfe_system_info:version atom
+              lfe_system_info:app_version atom
+              lfe_system_info:os_versions
+              lfe_system_info:core_versions
+              lfe_system_info:tool_versions
+              lfe_system_info:version
+              lfe_system_info:version atom
 
        Note  that an alias is provided for the last two as version, accessible
        both from LFE modules and the LFE REPL.

--- a/doc/man/lfe.1
+++ b/doc/man/lfe.1
@@ -113,6 +113,13 @@ Quit \- shorthand for \f[C]init:stop/0\f[].
 \f[B](regs)\f[]
 .PP
 Print information about the registered processes in the system.
+.PP
+\f[B](version)\f[]
+.PP
+Return a data structure of current version information.
+.PP
+\f[B](version App)\f[]
+.PP
 .SH BUILT\-IN SHELL COMMANDS
 .PP
 These are special forms which are only recognised at the top\-level in

--- a/doc/man/lfe_guide.7
+++ b/doc/man/lfe_guide.7
@@ -1433,6 +1433,150 @@ include file, the use of which allows developers to forego the
 (include-lib \[dq]lfe/include/clj.lfe\[dq])
 \f[R]
 .fi
+.SS Supplemental Common Lisp Functions
+.PP
+LFE provides the module cl which contains the following functions which
+closely mirror functions defined in the Common Lisp Hyperspec.
+Note that the following functions use zero\-based indices, like Common
+Lisp.
+A major difference is that the boolean values are the LFE \[aq]true and
+\[aq]false.
+Otherwise the definitions closely follow the CL definitions and
+won\[aq]t be documented here.
+.IP
+.nf
+\f[C]
+cl:make\-lfe\-bool\ cl\-value
+cl:make\-cl\-bool\ lfe\-bool
+
+cl:mapcar\ \ function\ \ list
+cl:maplist\ \ function\ \ list
+cl:mapc\ \ function\ \ list
+cl:mapl\ \ function\ \ list
+
+cl:symbol\-plist\ \ symbol
+cl:symbol\-name\ \ symbol
+cl:get\ \ symbol\ \ pname
+cl:get\ \ symbol\ \ pname\ \ default
+cl:getl\ \ symbol\ \ pname\-list
+cl:putprop\ \ symbol\ \ value\ \ pname
+cl:remprop\ \ symbol\ \ pname
+
+cl:getf\ \ plist\ \ pname
+cl:getf\ \ plist\ \ pname\ \ default
+cl:putf\ \ plist\ \ value\ \ pname\ \ \ \ \ \ \ \ \ \ \ \ This\ does\ not\ exist\ in\ CL
+cl:remf\ \ plist\ \ pname
+cl:get\-properties\ \ plist\ \ pname\-list
+
+cl:elt\ \ index\ \ sequence
+cl:length\ \ sequence
+cl:reverse\ \ sequence
+cl:some\ \ predicate\ \ sequence
+cl:every\ \ predicate\ \ sequence
+cl:notany\ \ predicate\ \ sequence
+cl:notevery\ \ predicate\ \ sequence
+cl:reduce\ \ function\ \ sequence
+cl:reduce\ \ function\ \ sequence\ \ \[aq]initial\-value\ \ x
+cl:reduce\ \ function\ \ sequence\ \ \[aq]from\-end\ \ \[aq]true
+cl:reduce\ \ function\ \ sequence\ \ \[aq]initial\-value\ \ x\ \ \[aq]from\-end\ \ \[aq]true
+
+cl:remove\ \ item\ \ sequence
+cl:remove\-if\ \ predicate\ \ sequence
+cl:remove\-if\-not\ \ predicate\ \ sequence
+cl:remove\-duplicates\ \ sequence
+
+cl:find\ \ item\ \ sequence
+cl:find\-if\ \ predicate\ \ sequence
+cl:find\-if\-not\ \ predicate\ \ sequence
+cl:find\-duplicates\ \ sequence
+cl:position\ \ item\ \ sequence
+cl:position\-if\ \ predicate\ \ sequence
+cl:position\-if\-not\ \ predicate\ \ sequence
+cl:position\-duplicates\ \ sequence
+cl:count\ \ item\ \ sequence
+cl:count\-if\ \ predicate\ \ sequence
+cl:count\-if\-not\ \ predicate\ \ sequence
+cl:count\-duplicates\ \ sequence
+
+cl:car\ \ list
+cl:first\ \ list
+cl:cdr\ \ list
+cl:rest\ \ list
+cl:nth\ \ index\ \ list
+cl:nthcdr\ \ index\ \ list
+cl:last\ \ list
+cl:butlast\ \ list
+
+cl:subst\ \ new\ \ old\ \ tree
+cl:subst\-if\ \ new\ \ test\ \ tree
+cl:subst\-if\-not\ \ new\ \ test\ \ tree
+cl:sublis\ \ alist\ \ tree
+
+cl:member\ \ item\ \ list
+cl:member\-if\ \ predicate\ \ list
+cl:member\-if\-not\ \ predicate\ \ list
+cl:adjoin\ \ item\ \ list
+cl:union\ \ list\ \ list
+cl:intersection\ \ list\ \ list
+cl:set\-difference\ \ list\ \ list
+cl:set\-exclusive\-or\ \ list\ \ list
+cl:subsetp\ \ list\ \ list
+
+cl:acons\ \ key\ \ data\ \ alist
+cl:pairlis\ \ list\ \ list
+cl:pairlis\ \ list\ \ list\ \ alist
+cl:assoc\ \ key\ \ alist
+cl:assoc\-if\ \ predicate\ \ alost
+cl:assoc\-if\-not\ \ predicate\ \ alost
+cl:rassoc\ \ key\ \ alist
+cl:rassoc\-if\ \ predicate\ \ alost
+cl:rassoc\-if\-not\ \ predicate\ \ alost
+
+cl:type\-of\ \ object
+cl:coerce\ \ object\ \ type
+\f[]
+.fi
+.PP
+Furthmore, there is an include file which developers may which to
+utilize in their LFE programs:
+\f[C](include\-lib\ "lfe/include/cl.lfe")\f[].
+Currently this offers Common Lisp predicates, but may include other
+useful macros and functions in the future.
+The provided predicate macros wrap the various \f[C]is_*\f[] Erlang
+functions; since these are expanded at compile time, they are usable in
+guards.
+The include the following:
+.IP
+.nf
+\f[C]
+(alivep\ x)
+(atomp\ x)
+(binaryp\ x)
+(bitstringp\ x)
+(boolp\ x)\ and\ (booleanp\ x)
+(builtinp\ x)
+(floatp\ x)
+(funcp\ x)\ and\ (functionp\ x)
+(intp\ x)\ and\ (integerp\ x)
+(listp\ x)
+(mapp\ x)
+(numberp\ x)
+(pidp\ x)
+(process\-alive\-p\ x)
+(recordp\ x\ tag)
+(recordp\ x\ tag\ size)
+(refp\ x)\ and\ (referencep\ x)
+(tuplep\ x)
+\f[]
+.fi
+.SS Utility and System Information Functions
+.PP
+lfe_system_info:app_version atom lfe_system_info:os_versions
+lfe_system_info:core_versions lfe_system_info:tool_versions
+lfe_system_info:version lfe_system_info:version atom
+.PP
+Note that an alias is provided for the last two as \f[C]version\f[],
+accessible both from LFE modules and the LFE REPL.
 .SH Notes
 .IP \[bu] 2
 NYI - Not Yet Implemented

--- a/doc/man/lfe_guide.7
+++ b/doc/man/lfe_guide.7
@@ -1570,10 +1570,17 @@ The include the following:
 \f[]
 .fi
 .SS Utility and System Information Functions
-.PP
-lfe_system_info:app_version atom lfe_system_info:os_versions
-lfe_system_info:core_versions lfe_system_info:tool_versions
-lfe_system_info:version lfe_system_info:version atom
+.IP
+.nf
+\f[C]
+lfe_system_info:app_version\ atom
+lfe_system_info:os_versions
+lfe_system_info:core_versions
+lfe_system_info:tool_versions
+lfe_system_info:version
+lfe_system_info:version\ atom
+\f[]
+.fi
 .PP
 Note that an alias is provided for the last two as \f[C]version\f[],
 accessible both from LFE modules and the LFE REPL.

--- a/doc/src/lfe.1.md
+++ b/doc/src/lfe.1.md
@@ -113,6 +113,13 @@ Quit - shorthand for ``init:stop/0``.
 
 Print information about the registered processes in the system.
 
+**(version)**
+
+Return a data structure of current version information.
+
+**(version App)**
+
+Print information about the registered processes in the system.
 
 # BUILT-IN SHELL COMMANDS
 

--- a/doc/src/lfe_guide.7.md
+++ b/doc/src/lfe_guide.7.md
@@ -1325,6 +1325,20 @@ the use of which allows developers to forego the `clj:` prefix in calls:
 (include-lib "lfe/include/clj.lfe")
 ```
 
+## Utility and System Information Functions
+
+```
+lfe_system_info:app_version atom
+lfe_system_info:os_versions
+lfe_system_info:core_versions
+lfe_system_info:tool_versions
+lfe_system_info:version
+lfe_system_info:version atom
+```
+
+Note that an alias is provided for the last two as `version`, accessible both
+from LFE modules and the LFE REPL.
+
 # Notes
 
 * NYI - Not Yet Implemented

--- a/doc/user_guide.txt
+++ b/doc/user_guide.txt
@@ -1109,6 +1109,137 @@ Predefined LFE functions
 
               (include‐lib "lfe/include/clj.lfe")
 
+   Supplemental Common Lisp Functions
+       LFE provides the module cl which contains the following functions which
+       closely mirror functions defined in the Common  Lisp  Hyperspec.   Note
+       that  the following functions use zero−based indices, like Common Lisp.
+       A major difference is that the boolean values are  the  LFE  'true  and
+       'false.   Otherwise  the  definitions closely follow the CL definitions
+       and won't be documented here.
+
+              cl:make−lfe−bool cl−value
+              cl:make−cl−bool lfe−bool
+
+              cl:mapcar  function  list
+              cl:maplist  function  list
+              cl:mapc  function  list
+              cl:mapl  function  list
+
+              cl:symbol−plist  symbol
+              cl:symbol−name  symbol
+              cl:get  symbol  pname
+              cl:get  symbol  pname  default
+              cl:getl  symbol  pname−list
+              cl:putprop  symbol  value  pname
+              cl:remprop  symbol  pname
+
+              cl:getf  plist  pname
+              cl:getf  plist  pname  default
+              cl:putf  plist  value  pname            This does not exist in CL
+              cl:remf  plist  pname
+              cl:get−properties  plist  pname−list
+
+              cl:elt  index  sequence
+              cl:length  sequence
+              cl:reverse  sequence
+              cl:some  predicate  sequence
+              cl:every  predicate  sequence
+              cl:notany  predicate  sequence
+              cl:notevery  predicate  sequence
+              cl:reduce  function  sequence
+              cl:reduce  function  sequence  'initial−value  x
+              cl:reduce  function  sequence  'from−end  'true
+              cl:reduce  function  sequence  'initial−value  x  'from−end  'true
+
+              cl:remove  item  sequence
+              cl:remove−if  predicate  sequence
+              cl:remove−if−not  predicate  sequence
+              cl:remove−duplicates  sequence
+
+              cl:find  item  sequence
+              cl:find−if  predicate  sequence
+              cl:find−if−not  predicate  sequence
+              cl:find−duplicates  sequence
+              cl:position  item  sequence
+              cl:position−if  predicate  sequence
+              cl:position−if−not  predicate  sequence
+              cl:position−duplicates  sequence
+              cl:count  item  sequence
+              cl:count−if  predicate  sequence
+              cl:count−if−not  predicate  sequence
+              cl:count−duplicates  sequence
+
+              cl:car  list
+              cl:first  list
+              cl:cdr  list
+              cl:rest  list
+              cl:nth  index  list
+              cl:nthcdr  index  list
+              cl:last  list
+              cl:butlast  list
+
+              cl:subst  new  old  tree
+              cl:subst−if  new  test  tree
+              cl:subst−if−not  new  test  tree
+              cl:sublis  alist  tree
+
+              cl:member  item  list
+              cl:member−if  predicate  list
+              cl:member−if−not  predicate  list
+              cl:adjoin  item  list
+              cl:union  list  list
+              cl:intersection  list  list
+              cl:set−difference  list  list
+              cl:set−exclusive−or  list  list
+              cl:subsetp  list  list
+
+              cl:acons  key  data  alist
+              cl:pairlis  list  list
+              cl:pairlis  list  list  alist
+              cl:assoc  key  alist
+              cl:assoc−if  predicate  alost
+              cl:assoc−if−not  predicate  alost
+              cl:rassoc  key  alist
+              cl:rassoc−if  predicate  alost
+              cl:rassoc−if−not  predicate  alost
+
+              cl:type−of  object
+              cl:coerce  object  type
+
+       Furthmore, there is an include file which developers may which to  uti‐
+       lize  in  their LFE programs: (include−lib "lfe/include/cl.lfe").  Cur‐
+       rently this offers Common Lisp predicates, but may include other useful
+       macros and functions in the future.  The provided predicate macros wrap
+       the various is_* Erlang functions; since these are expanded at  compile
+       time, they are usable in guards.  The include the following:
+
+              (alivep x)
+              (atomp x)
+              (binaryp x)
+              (bitstringp x)
+              (boolp x) and (booleanp x)
+              (builtinp x)
+              (floatp x)
+              (funcp x) and (functionp x)
+              (intp x) and (integerp x)
+              (listp x)
+              (mapp x)
+              (numberp x)
+              (pidp x)
+              (process−alive−p x)
+              (recordp x tag)
+              (recordp x tag size)
+              (refp x) and (referencep x)
+              (tuplep x)
+
+   Utility and System Information Functions
+       lfe_system_info:app_version  atom  lfe_system_info:os_versions lfe_sys‐
+       tem_info:core_versions   lfe_system_info:tool_versions   lfe_system_in‐
+       fo:version lfe_system_info:version atom
+
+       Note  that an alias is provided for the last two as version, accessible
+       both from LFE modules and the LFE REPL.
+
 Notes
        · NYI ‐ Not Yet Implemented
 

--- a/doc/user_guide.txt
+++ b/doc/user_guide.txt
@@ -1233,9 +1233,12 @@ Predefined LFE functions
               (tuplep x)
 
    Utility and System Information Functions
-       lfe_system_info:app_version  atom  lfe_system_info:os_versions lfe_sys‐
-       tem_info:core_versions   lfe_system_info:tool_versions   lfe_system_in‐
-       fo:version lfe_system_info:version atom
+              lfe_system_info:app_version atom
+              lfe_system_info:os_versions
+              lfe_system_info:core_versions
+              lfe_system_info:tool_versions
+              lfe_system_info:version
+              lfe_system_info:version atom
 
        Note  that an alias is provided for the last two as version, accessible
        both from LFE modules and the LFE REPL.

--- a/examples/version.lfe
+++ b/examples/version.lfe
@@ -1,0 +1,50 @@
+;; Copyright (c) 2016 Duncan McGreggor <oubiwann@cogitat.io>
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; File    : version.lfe
+;; Author  : Duncan McGreggor
+;; Purpose : Demonstrating module call and macro/alias call to version function
+
+;; Here is some example usage:
+;;
+;; lfe> (slurp "example/version.lfe")
+;; #(ok version)
+;;
+;; Not that after the first call to `version` or `lfe_system_info:version`,
+;; the results are memoized and thus subsequent calls are much faster.
+;;
+;; lfe> (get-version-1)
+;; ...
+;; lfe> (get-version-2)
+;; ...
+;; lfe> (get-lfe-version-1)
+;; ...
+;; lfe> (get-lfe-version-2)
+;; ...
+
+(defmodule version
+  (export all))
+
+(defun get-version-1 ()
+  (lfe_system_info:version))
+
+(defun get-version-2 ()
+  (version))
+
+(defun get-lfe-version-1 ()
+  (lfe_system_info:version 'lfe))
+
+(defun get-lfe-version-2 ()
+  (version 'lfe))
+

--- a/src/lfe_macro.erl
+++ b/src/lfe_macro.erl
@@ -743,6 +743,10 @@ exp_predef([cddadr,E], _, St) -> {yes,[cdr,[cdr,[car,[cdr,E]]]],St};
 exp_predef([cdddar,E], _, St) -> {yes,[cdr,[cdr,[cdr,[car,E]]]],St};
 exp_predef([cddddr,E], _, St) -> {yes,[cdr,[cdr,[cdr,[cdr,E]]]],St};
 
+%% Alias macro for version info
+exp_predef([version], _, St) -> {yes, [':',lfe_system_info,version], St};
+exp_predef([version,A], _, St) -> {yes, [':',lfe_system_info,version,A], St};
+
 %% Arithmetic operations and comparison operations.
 %% Be careful to make these behave as if they were a function and
 %% strictly evalated all their arguments.

--- a/src/lfe_shell.erl
+++ b/src/lfe_shell.erl
@@ -34,7 +34,7 @@
 %% The shell commands which generally callable.
 -export([c/1,c/2,cd/1,doc/1,ec/1,ec/2,ep/1,ep/2,epp/1,epp/2,help/0,
          i/0,i/1,l/1,ls/1,clear/0,m/0,m/1,pid/3,p/1,p/2,pp/1,pp/2,pwd/0,
-         q/0,flush/0,regs/0,exit/0]).
+         q/0,flush/0,regs/0,exit/0,version/0,version/1]).
 
 -import(lfe_env, [new/0,add_env/2,
                   add_vbinding/3,add_vbindings/2,is_vbound/2,get_vbinding/2,
@@ -345,7 +345,9 @@ add_shell_functions(Env0) ->
           {q,0,[lambda,[],[':',lfe_shell,exit]]},
           {flush,0,[lambda,[],[':',lfe_shell,flush]]},
           {regs,0,[lambda,[],[':',lfe_shell,regs]]},
-          {exit,0,[lambda,[],[':',lfe_shell,exit]]}
+          {exit,0,[lambda,[],[':',lfe_shell,exit]]},
+          {version,0,[lambda,[],[':',lfe_shell,version]]},
+          {version,1,[lambda,[app],[':',lfe_shell,version,app]]}
          ],
     %% Any errors here will crash shell startup!
     Add = fun ({N,Ar,Def}, E) ->
@@ -824,7 +826,8 @@ help() ->
                    "(pid x y z)    -- convert <x>, <y> and <z> to a pid\n"
                    "(pwd)          -- print working directory\n"
                    "(q)            -- quit - shorthand for init:stop/0\n"
-                   "(regs)         -- information about registered processes\n\n"
+                   "(regs)         -- information about registered processes\n"
+                   "(version)   -- provide version information for os, core apps, and tools\n\n"
                    "LFE shell built-in commands\n\n"
                    "(reset-environment)             -- reset the environment to its initial state\n"
                    "(run file)                      -- execute all the shell commands in a <file>\n"
@@ -1010,6 +1013,14 @@ regs() -> c:regs().
 %% exit() -> ok.
 
 exit() -> c:q().
+
+%% version() -> [tuple()].
+%% version([App]) -> list().
+%%  Return version data for key apps or a single app
+
+version() -> lfe_system_info:version().
+
+version(App) -> lfe_system_info:version(App).
 
 %% doc(Fun) -> ok | {error,Error}.
 %%  Print out documentation of a module/macro/function. Always try to

--- a/src/lfe_shell.erl
+++ b/src/lfe_shell.erl
@@ -259,6 +259,18 @@ make_banner() ->
        ?GRN("    \\   ") ++ ?RED("r") ++ ?GRN("     /") ++  "      |   LFE v~s ~s\n" ++
        ?GRN("     `-") ++ ?RED("E") ++ ?GRN("___.-'") ++ "\n\n", [get_lfe_version(), get_abort_message()])].
 
+display_banner() ->
+    %% When LFE is called with -noshell, we want to skip the banner. Also, there may be
+    %% circumstances where the shell is desired, but the banner needs to be disabled,
+    %% thus we want to support both use cases.
+    case init:get_argument(noshell) of
+        error -> case init:get_argument(nobanner) of
+                    error -> io:put_chars(make_banner());
+                    _ -> false
+                 end;
+        _ -> false
+    end.
+
 get_abort_message() ->
     %% We can update this later to check for env variable settings for
     %% shells that require a different control character to abort, such

--- a/src/lfe_system_info.erl
+++ b/src/lfe_system_info.erl
@@ -1,0 +1,111 @@
+%% Copyright (c) 2008-2016 Robert Virding
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% File    : lfe_system_info.erl
+%% Author  : Duncan McGreggor
+%% Purpose : Lisp Flavoured Erlang functions returning system data.
+
+-module(lfe_system_info).
+
+-export([app_version/1,
+         os_versions/0,
+         core_versions/0,
+         tool_versions/0,
+         version/0, version/1]).
+
+-define(APP_LOOKUP_ERROR, {error, 'app-not-found'}).
+-define(TOOL_LOOKUP_ERROR, {error, 'tool-not-found'}).
+-define(NEWLINE, 10).
+
+trim(String) ->
+    string:strip(String, both, ?NEWLINE).
+
+cmd(String) ->
+    trim(os:cmd(String)).
+
+app_version(AppName) ->
+    application:load(AppName),
+    case application:get_key(AppName, vsn) of
+        {ok,Vsn} -> Vsn;
+        _ -> ?APP_LOOKUP_ERROR
+    end.
+
+os_version () ->
+    case os:type() of
+        {unix, _} -> [{os, cmd("uname -a")}];
+        {_, nt} -> [{os, cmd("ver")}];
+        _ -> []
+    end.
+
+kernel_version() ->
+    case os:type() of
+        {unix, _} -> [{kernel, os:version()}];
+        _ -> []
+    end.
+
+os_versions() ->
+    os_version() ++ kernel_version().
+
+core_versions() ->
+    [{otp, erlang:system_info(otp_release)},
+     {emulator, erlang:system_info(version)},
+     {system, trim(erlang:system_info(system_version))},
+     {driver, erlang:system_info(driver_version)},
+     {nif, erlang:system_info(nif_version)},
+     {lfe, app_version(lfe)}].
+
+rebar_version() ->
+    case os:find_executable(rebar) of
+        false -> [];
+        _ -> [{rebar, cmd("rebar --version")}]
+    end.
+
+rebar3_version() ->
+    case os:find_executable(rebar3) of
+        false -> [];
+        _ -> [{rebar3, cmd("rebar3 --version")}]
+    end.
+
+mix_version() ->
+    case os:find_executable(mix) of
+        false -> [];
+        _ -> [{mix, cmd("mix --version")}]
+    end.
+
+relx_version() ->
+    case os:find_executable(relx) of
+        false -> [];
+        _ -> [{relx, cmd("relx --version")}]
+    end.
+
+tool_versions() ->
+    rebar_version() ++ rebar3_version() ++ mix_version() ++ relx_version().
+
+uncached_version() ->
+    os_versions() ++ core_versions() ++ tool_versions().
+
+version() ->
+    case erlang:get(lfe_version_info) of
+        undefined -> Ver = uncached_version(),
+                     erlang:put(lfe_version_info, Ver),
+                     Ver;
+        Vsn -> Vsn
+    end.
+
+version(AppName) ->
+    case proplists:get_value(AppName, version()) of
+        {error, _} -> ?APP_LOOKUP_ERROR;
+        undefined -> ?APP_LOOKUP_ERROR;
+        Vsn -> Vsn
+    end.

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -24,7 +24,7 @@
 
 (defmacro ok? (x) `(=:= 'ok ,x))
 
-;; HACK
+;; XXX HACK
 (defmacro IFF-MAPS expr `(andalso (erl_internal:bif 'is_map 1) ,@expr))
 
 ;;; defn


### PR DESCRIPTION
Fixes #297.

Add support for a `version` function as well as other "system info" functions. Tasks:

* [x] provide Erlang, LFE, OS, and tools version info
* [x] allow users to only provide the version of a single entry, if they so wish
* [x] use an extensible and backwards compatible data structure (property list)
* [x] provide convenience macros for use by developers in the REPL (e.g., `(version)` and `(version 'app-nam)`)
* [x] ensure new functions are accessible from any LFE module
* [ ] cache expensive calls
   * [x] memoize where sensible to mitigate expensive system calls
   * [ ] refactor memoization to instead use the processes table (see @rvirding's comment below)
* [ ] add documentation
   * [ ] update lfe_shell.md
   * [ ] update lfe.1.md

Bonus tasks:

* [x] add missing docs for Common Lisp module
