### PR TITLE
[clj] Crucial fixes

### DIFF
--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -232,7 +232,7 @@
 
 (defmacro not=
   "Same as `(not (== ...))`."
-  (`(,x)            'false)
+  (`(,x)            `'false)
   (`(,x ,y . ,more) `(not (== ,x ,y ,@more))))
 
 

--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -751,7 +751,7 @@
   (flet ((dict-find [k d]
                     (case (dict:fetch k d)
                       (`#(ok ,v) v)
-                      ('errror   not-found))))
+                      ('error    not-found))))
     (-get-in #'dict-find/2 dict keys)))
 
 (defn- -get-in-map

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -172,6 +172,7 @@
   (is (clj:when-not 'false 'true)))
 
 (deftest not=
+  (is-not (clj:not= 42))
   (is-not (clj:not= 42 42))
   (is (clj:not= 42 123)))
 


### PR DESCRIPTION
- Fix (and test) unary clause of `not=`
- Fix typo in `-get-in-dict/3`: `errror` -> `error`