### PR TITLE
[clj] Change the meaning of truthiness

### DIFF
--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -330,6 +330,21 @@ EXPORTS
               > (clj:str "a" "bc")
               "abc"
 
+       (lazy-seq)
+
+       (lazy-seq seq)
+
+       Return  a  (possibly infinite) lazy sequence from a given lazy sequence
+       seq or a finite lazy sequence from given list seq.  A lazy sequence  is
+       treated  as  finite if at any iteration it produces the empty list, in‐
+       stead of a cons cell with data as the head and a nullary  function  for
+       the next iteration as the tail.
+
+       (conj coll . xs)
+
+       conj[oin]  a value onto an existing collection.  Prepend to a list, ap‐
+       pend to a tuple, and merge maps.
+
    Function Composition
        (comp f g)
 

--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -287,6 +287,10 @@ EXPORTS
 
        Return 'true if x is the atom 'false.
 
+       (falsy? x)
+
+       Return 'true if x is one of the atoms 'false and 'undefined.
+
        (odd? x)
 
        Return 'true if x is odd.

--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -131,26 +131,28 @@ EXPORTS
        (cond-> expr . clauses)
 
        Given  an  expression  and  a set of test/sexp pairs, thread x (via ->)
-       through each sexp for which the corresponding test expression is 'true.
-       Note  that, unlike cond branching, cond-> threading does not short cir‐
-       cuit after the first 'true test expression.
+       through each sexp  for  which  the  corresponding  test  expression  is
+       truthy,  i.e.   neither  'false nor 'undefined.  Note that, unlike cond
+       branching, cond-> threading does not  short  circuit  after  the  first
+       truthy test expression.
 
        (cond->> expr . clauses)
 
-       Given an expression and a set of test/sexp pairs, thread  x  (via  ->>)
-       through each sexp for which the corresponding test expression is 'true.
-       Note that, unlike cond branching, cond->> threading does not short cir‐
-       cuit after the first 'true test expression.
+       Given  an  expression  and a set of test/sexp pairs, thread x (via ->>)
+       through each sexp  for  which  the  corresponding  test  expression  is
+       truthy,  i.e.   neither  'false nor 'undefined.  Note that, unlike cond
+       branching, cond->> threading does not short  circuit  after  the  first
+       truthy test expression.
 
        (some-> x . sexps)
 
-       When  x  is  not undefined, thread it into the first sexp (via ->), and
-       when that result is not undefined, through the next, etc.
+       When  x  is not 'undefined, thread it into the first sexp (via ->), and
+       when that result is not 'undefined, through the next, etc.
 
        (some->> x . sexps)
 
-       When x is not undefined, thread it into the first sexp (via  ->>),  and
-       when that result is not undefined, through the next, etc.
+       When x is not 'undefined, thread it into the first sexp (via ->>),  and
+       when that result is not 'undefined, through the next, etc.
 
    Conditional Macros
        (condp pred expr . clauses)
@@ -163,7 +165,7 @@ EXPORTS
               test-expr >> result-fn
 
        where result-fn is a unary function, if  (pred test-expr expr)  returns
-       anything other than undefined or 'false, the clause is a match.
+       anything other than 'undefined or 'false, the clause is a match.
 
        If  a  binary  clause matches, return result-expr.  If a ternary clause
        matches, call result-fn with the result of the predicate and return the
@@ -177,18 +179,18 @@ EXPORTS
 
        (if-not test then else)
 
-       If  test evaluates to 'false, evaluate and return then, otherwise else,
-       if supplied, else 'false.
+       If  test  evaluates  to 'false or 'undefined, evaluate and return then,
+       otherwise else, if supplied, else 'undefined.
 
        (iff test . body)
 
-       Like Clojure's when.  Evaluate test.  If 'true, evaluate body in an im‐
-       plicit progn.
+       Like Clojure's when.  If test evaluates to anything other  than  'false
+       or 'undefined, evaluate body in an implicit progn.
 
        (when-not test . body)
 
-       If test evaluates to 'false, evaluate body in an implicit progn, other‐
-       wise if test evaluates to 'true, return 'false.
+       If test evaluates to 'false or 'undefined, evaluate body in an implicit
+       progn.  Otherwise return 'undefined.
 
        (not= x)
 

--- a/doc/lfe_clj.txt
+++ b/doc/lfe_clj.txt
@@ -345,6 +345,14 @@ EXPORTS
        conj[oin]  a value onto an existing collection.  Prepend to a list, ap‐
        pend to a tuple, and merge maps.
 
+   Clojure-inspired if Macro
+       (if test then)
+
+       (if test then else)
+
+       If test evaluates to anything other than 'false or  'undefined,  return
+       then, otherwise else, if given, else 'undefined.
+
    Function Composition
        (comp f g)
 

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -345,6 +345,11 @@ Return \f[C]\[aq]true\f[] if \f[C]x\f[] is the atom \f[C]\[aq]true\f[].
 .PP
 Return \f[C]\[aq]true\f[] if \f[C]x\f[] is the atom \f[C]\[aq]false\f[].
 .PP
+\f[B](falsy? x)\f[]
+.PP
+Return \f[C]\[aq]true\f[] if \f[C]x\f[] is one of the atoms
+\f[C]\[aq]false\f[] and \f[C]\[aq]undefined\f[].
+.PP
 \f[B](odd? x)\f[]
 .PP
 Return \f[C]\[aq]true\f[] if \f[C]x\f[] is odd.

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -410,6 +410,15 @@ function for the next iteration as the tail.
 .PP
 conj[oin] a value onto an existing collection.
 Prepend to a list, append to a tuple, and merge maps.
+.SS Clojure\-inspired \f[I]if\f[] Macro
+.PP
+\f[B](if test then)\f[]
+.PP
+\f[B](if test then else)\f[]
+.PP
+If \f[C]test\f[] evaluates to anything other than \f[C]\[aq]false\f[] or
+\f[C]\[aq]undefined\f[], return \f[C]then\f[], otherwise \f[C]else\f[],
+if given, else \f[C]\[aq]undefined\f[].
 .SS Function Composition
 .PP
 \f[B](comp f g)\f[]

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -167,33 +167,31 @@ returning the result of the last \f[C]sexp\f[].
 .PP
 Given an \f[C]expr\f[]ession and a set of \f[C]test\f[]/\f[C]sexp\f[]
 pairs, thread \f[C]x\f[] (via \f[B]\->\f[]) through each \f[C]sexp\f[]
-for which the corresponding \f[C]test\f[] expression is
-\f[C]\[aq]true\f[].
+for which the corresponding \f[C]test\f[] expression is truthy, i.e.
+neither \f[C]\[aq]false\f[] nor \f[C]\[aq]undefined\f[].
 Note that, unlike \f[B]cond\f[] branching, \f[B]cond\->\f[] threading
-does not short circuit after the first \f[C]\[aq]true\f[] test
-expression.
+does not short circuit after the first truthy test expression.
 .PP
 \f[B](cond\->> expr . clauses)\f[]
 .PP
 Given an \f[C]expr\f[]ession and a set of \f[C]test\f[]/\f[C]sexp\f[]
 pairs, thread \f[C]x\f[] (via \f[B]\->>\f[]) through each \f[C]sexp\f[]
-for which the corresponding \f[C]test\f[] expression is
-\f[C]\[aq]true\f[].
+for which the corresponding \f[C]test\f[] expression is truthy, i.e.
+neither \f[C]\[aq]false\f[] nor \f[C]\[aq]undefined\f[].
 Note that, unlike \f[B]cond\f[] branching, \f[B]cond\->>\f[] threading
-does not short circuit after the first \f[C]\[aq]true\f[] \f[C]test\f[]
-expression.
+does not short circuit after the first truthy \f[C]test\f[] expression.
 .PP
 \f[B](some\-> x . sexps)\f[]
 .PP
-When \f[C]x\f[] is not \f[C]undefined\f[], thread it into the first
+When \f[C]x\f[] is not \f[C]\[aq]undefined\f[], thread it into the first
 \f[C]sexp\f[] (via \f[B]\->\f[]), and when that result is not
-\f[C]undefined\f[], through the next, etc.
+\f[C]\[aq]undefined\f[], through the next, etc.
 .PP
 \f[B](some\->> x . sexps)\f[]
 .PP
-When \f[C]x\f[] is not \f[C]undefined\f[], thread it into the first sexp
-(via \f[B]\->>\f[]), and when that result is not \f[C]undefined\f[],
-through the next, etc.
+When \f[C]x\f[] is not \f[C]\[aq]undefined\f[], thread it into the first
+\f[C]sexp\f[] (via \f[B]\->>\f[]), and when that result is not
+\f[C]\[aq]undefined\f[], through the next, etc.
 .SS Conditional Macros
 .PP
 \f[B](condp pred expr . clauses)\f[]
@@ -211,7 +209,7 @@ test\-expr\ >>\ result\-fn
 .PP
 where \f[C]result\-fn\f[] is a unary function, if
 \f[C](pred\ test\-expr\ expr)\f[] returns anything other than
-\f[C]undefined\f[] or \f[C]\[aq]false\f[], the clause is a match.
+\f[C]\[aq]undefined\f[] or \f[C]\[aq]false\f[], the clause is a match.
 .PP
 If a binary clause matches, return \f[C]result\-expr\f[].
 If a ternary clause matches, call \f[C]result\-fn\f[] with the result of
@@ -226,22 +224,23 @@ If no default expression is given and no clause matches, throw a
 .PP
 \f[B](if\-not test then else)\f[]
 .PP
-If \f[C]test\f[] evaluates to \f[C]\[aq]false\f[], evaluate and return
-\f[C]then\f[], otherwise \f[C]else\f[], if supplied, else
-\f[C]\[aq]false\f[].
+If \f[C]test\f[] evaluates to \f[C]\[aq]false\f[] or
+\f[C]\[aq]undefined\f[], evaluate and return \f[C]then\f[], otherwise
+\f[C]else\f[], if supplied, else \f[C]\[aq]undefined\f[].
 .PP
 \f[B](iff test . body)\f[]
 .PP
 Like Clojure\[aq]s \f[C]when\f[].
-Evaluate \f[C]test\f[].
-If \f[C]\[aq]true\f[], evaluate \f[C]body\f[] in an implicit
+If \f[C]test\f[] evaluates to anything other than \f[C]\[aq]false\f[] or
+\f[C]\[aq]undefined\f[], evaluate \f[C]body\f[] in an implicit
 \f[C]progn\f[].
 .PP
 \f[B](when\-not test . body)\f[]
 .PP
-If \f[C]test\f[] evaluates to \f[C]\[aq]false\f[], evaluate
-\f[C]body\f[] in an implicit \f[C]progn\f[], otherwise if \f[C]test\f[]
-evaluates to \f[C]\[aq]true\f[], return \f[C]\[aq]false\f[].
+If \f[C]test\f[] evaluates to \f[C]\[aq]false\f[] or
+\f[C]\[aq]undefined\f[], evaluate \f[C]body\f[] in an implicit
+\f[C]progn\f[].
+Otherwise return \f[C]\[aq]undefined\f[].
 .PP
 \f[B](not= x)\f[]
 .PP

--- a/doc/man/lfe_clj.3
+++ b/doc/man/lfe_clj.3
@@ -395,6 +395,21 @@ integer value, i.e.
 "abc"
 \f[]
 .fi
+.PP
+\f[B](lazy\-seq)\f[]
+.PP
+\f[B](lazy\-seq seq)\f[]
+.PP
+Return a (possibly infinite) lazy sequence from a given lazy sequence
+\f[C]seq\f[] or a finite lazy sequence from given list \f[C]seq\f[].
+A lazy sequence is treated as finite if at any iteration it produces the
+empty list, instead of a cons cell with data as the head and a nullary
+function for the next iteration as the tail.
+.PP
+\f[B](conj coll . xs)\f[]
+.PP
+conj[oin] a value onto an existing collection.
+Prepend to a list, append to a tuple, and merge maps.
 .SS Function Composition
 .PP
 \f[B](comp f g)\f[]

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -358,6 +358,21 @@ integer value, i.e. `"97"`.
 "abc"
 ```
 
+**(lazy-seq)**
+
+**(lazy-seq seq)**
+
+Return a (possibly infinite) lazy sequence from a given lazy sequence `seq`
+or a finite lazy sequence from given list `seq`.
+A lazy sequence is treated as finite if at any iteration it produces
+the empty list, instead of a cons cell with data as the head and a
+nullary function for the next iteration as the tail.
+
+**(conj coll . xs)**
+
+conj[oin] a value onto an existing collection.
+Prepend to a list, append to a tuple, and merge maps.
+
 
 ## Function Composition
 

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -152,26 +152,28 @@ in `sexps`, returning the result of the last `sexp`.
 **(cond-> expr . clauses)**
 
 Given an `expr`ession and a set of `test`/`sexp` pairs, thread `x` (via **->**)
-through each `sexp` for which the corresponding `test` expression is `'true`.
+through each `sexp` for which the corresponding `test` expression is truthy,
+i.e. neither `'false` nor `'undefined`.
 Note that, unlike **cond** branching, **cond->** threading does not short
-circuit after the first `'true` test expression.
+circuit after the first truthy test expression.
 
 **(cond->> expr . clauses)**
 
 Given an `expr`ession and a set of `test`/`sexp` pairs, thread `x` (via **->>**)
-through each `sexp` for which the corresponding `test` expression is `'true`.
+through each `sexp` for which the corresponding `test` expression is truthy,
+i.e. neither `'false` nor `'undefined`.
 Note that, unlike **cond** branching, **cond->>** threading does not short
-circuit after the first `'true` `test` expression.
+circuit after the first truthy `test` expression.
 
 **(some-> x . sexps)**
 
-When `x` is not `undefined`, thread it into the first `sexp` (via **->**),
-and when that result is not `undefined`, through the next, etc.
+When `x` is not `'undefined`, thread it into the first `sexp` (via **->**),
+and when that result is not `'undefined`, through the next, etc.
 
 **(some->> x . sexps)**
 
-When `x` is not `undefined`, thread it into the first sexp (via **->>**),
-and when that result is not `undefined`, through the next, etc.
+When `x` is not `'undefined`, thread it into the first `sexp` (via **->>**),
+and when that result is not `'undefined`, through the next, etc.
 
 
 ## Conditional Macros
@@ -187,7 +189,7 @@ test-expr >> result-fn
 ```
 
 where `result-fn` is a unary function, if `(pred test-expr expr)` returns
-anything other than `undefined` or `'false`, the clause is a match.
+anything other than `'undefined` or `'false`, the clause is a match.
 
 If a binary clause matches, return `result-expr`. If a ternary clause matches,
 call `result-fn` with the result of the predicate and return the result.
@@ -200,18 +202,19 @@ return it. If no default expression is given and no clause matches, throw a
 
 **(if-not test then else)**
 
-If `test` evaluates to `'false`, evaluate and return `then`, otherwise `else`,
-if supplied, else `'false`.
+If `test` evaluates to `'false` or `'undefined`, evaluate and return `then`,
+otherwise `else`, if supplied, else `'undefined`.
 
 **(iff test . body)**
 
 Like Clojure's `when`.
-Evaluate `test`. If `'true`, evaluate `body` in an implicit `progn`.
+If `test` evaluates to anything other than `'false` or `'undefined`,
+evaluate `body` in an implicit `progn`.
 
 **(when-not test . body)**
 
-If `test` evaluates to `'false`, evaluate `body` in an implicit `progn`,
-otherwise if `test` evaluates to `'true`, return `'false`.
+If `test` evaluates to `'false` or `'undefined`, evaluate `body`
+in an implicit `progn`. Otherwise return `'undefined`.
 
 **(not= x)**
 

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -311,6 +311,10 @@ Return `'true` if `x` is the atom `'true`.
 
 Return `'true` if `x` is the atom `'false`.
 
+**(falsy? x)**
+
+Return `'true` if `x` is one of the atoms `'false` and `'undefined`.
+
 **(odd? x)**
 
 Return `'true` if `x` is odd.

--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -374,6 +374,16 @@ conj[oin] a value onto an existing collection.
 Prepend to a list, append to a tuple, and merge maps.
 
 
+## Clojure-inspired *if* Macro
+
+**(if test then)**
+
+**(if test then else)**
+
+If `test` evaluates to anything other than `'false` or `'undefined`,
+return `then`, otherwise `else`, if given, else `'undefined`.
+
+
 ## Function Composition
 
 **(comp f g)**

--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -30,7 +30,9 @@
    integer? int? number? record? reference? map? undefined? undef? nil?
    true? false? falsy? odd? even? zero? pos? neg? identical?)
   ;; Other macros.
-  (export-macro str lazy-seq conj))
+  (export-macro str lazy-seq conj)
+  ;; Clojure-inspired if macro.
+  (export-macro if))
 
 (defmacro HAS_MAPS () (quote (erl_internal:bif 'is_map 1)))
 
@@ -770,3 +772,18 @@
    (-cycle (funcall f) lst))
   ([`(,head . ,tail) lst]
    (cons head (fn [] (-cycle tail (cons head lst))))))
+
+;;; Clojure-inspired if macro.
+
+(defmacro if args
+  "test then {{else}}
+  If `test` evaluates to anything other than `'false` or `'undefined`,
+  return `then`, otherwise `else`, if given, else `'undefined`."
+  (flet ((exp-if (test then else)
+           `(case ,test
+              ('false     ,else)
+              ('undefined ,else)
+              (_          ,then))))
+    (case args
+      ((list test then)      (exp-if test then `'undefined))
+      ((list test then else) (exp-if test then else)))))

--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -28,7 +28,7 @@
   (export-macro
    tuple? atom? binary? bitstring? boolean? bool? float? function? func?
    integer? int? number? record? reference? map? undefined? undef? nil?
-   true? false? odd? even? zero? pos? neg? identical?)
+   true? false? falsy? odd? even? zero? pos? neg? identical?)
   ;; Other macros.
   (export-macro str lazy-seq conj))
 
@@ -331,6 +331,10 @@
 (defmacro false? (x)
   "Return `'true` if `x` is the atom `'false`."
   `(=:= 'false ,x))
+
+(defmacro falsy? (x)
+  "Return `'true` if `x` is one of the atoms `'false` and `'undefined`."
+  `(orelse (=:= 'false ,x) (=:= 'undefined ,x)))
 
 (defmacro odd? (x)
   "Return `'true` if `x` is odd."

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -406,6 +406,14 @@
   (is-not (clj:false? 'true))
   (is (clj:false? 'false)))
 
+(deftest falsy?
+  (is-not (clj:falsy? 'true))
+  (is-not (clj:falsy? 42))
+  (is-not (clj:falsy? ()))
+  (is (clj:falsy? 'false))
+  (is (clj:falsy? 'undefined))
+  (is (clj:falsy? (proplists:get_value 42 ()))))
+
 (deftest odd?
   (is-not (clj:odd? 42))
   (is (clj:odd? 333)))

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -164,12 +164,14 @@
   (are* [x y] (ok? (is-match x y))
         1 (clj:iff 'true 1)
         () (clj:iff 'true)
-        'false (clj:iff 'false)
-        'false (clj:iff 'false (error 'bad-iff))))
+        'undefined (clj:iff 'false)
+        'undefined (clj:iff 'undefined)
+        'undefined (clj:iff 'false (error 'bad-iff))))
 
 (deftest when-not
-  (is-not (clj:when-not 'true 'ok))
-  (is (clj:when-not 'false 'true)))
+  (is-match 'undefined (clj:when-not 'true 'ok))
+  (is-match 'true (clj:when-not 'false 'true))
+  (is-match 42 (clj:when-not 'undefined 42)))
 
 (deftest not=
   (is-not (clj:not= 42))


### PR DESCRIPTION
‼️ **Contentious ‼️ Needs Review** ‼️ 


Previously, truth was represented by the atoms `'true` and `'false`.

In this PR, `'undefined` are `'false` and *falsy* and everything else is *truthy*.

Now the `clj` module feels a bit more like Clojure, but instead of `nil` we use the atom `'undefined`.

/cc @rvirding @oubiwann @skovsgaard @profitware 
