### PR TITLE
Fix behavior of conj for lists with multiple arguments

### DIFF
--- a/src/clj.lfe
+++ b/src/clj.lfe
@@ -436,10 +436,12 @@
             (-lazy-seq ,'seq*)))))))
 
 (defmacro conj
-  "conj[oin] a value onto an existing collection.
-  Prepend to a list, append to a tuple, and merge maps."
+  "conj[oins] a value onto an existing collection, either a list, a tuple,
+ or a map. For lists this means prepending, for tuples appending,
+ and for maps merging."
   (`[,coll . ,xs]
-   `(cond ((is_list ,coll) (cons ,@xs ,coll))
+   `(cond ((is_list ,coll)
+           (++ (lists:reverse (list ,@xs)) ,coll))
           ((is_tuple ,coll)
            (lists:foldl (lambda (x acc) (erlang:append_element acc x))
                         ,coll

--- a/test/clj-tests.lfe
+++ b/test/clj-tests.lfe
@@ -529,7 +529,9 @@
 (deftest conj
   (is-match '(1 2 3 4) (clj:conj '(2 3 4) 1))
   (is-match '((1) 2 3 4) (clj:conj '(2 3 4) '(1)))
+  (is-match '(1 2 3 4) (clj:conj '(4) 3 2 1))
   (is-match #(a b c d) (clj:conj #(a b c) 'd))
+  (is-match #(a b c d) (clj:conj #(a) 'b 'c 'd))
   (is-match #(a b c #(d)) (clj:conj #(a b c) #(d)))
   (IFF-MAPS
    (is-equal (maps:from_list '(#(a 1) #(b 2)))


### PR DESCRIPTION
Fixes #308.

I can't work out if the argument order is unintuitive, i.e. that the first arguments are prepended first rather than last. If anyone has feedback I'd love to hear some.