### PR TITLE
Issue/326/improve make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ DESTBINDIR := $(DESTLIBDIR)/$(BINDIR)
 
 VPATH = $(SRCDIR)
 
+MKDIR_P = mkdir -p
+
 ERLCFLAGS = -W1
 ERLC = erlc
 
@@ -72,7 +74,7 @@ $(BINDIR)/%: $(CSRCDIR)/%.c
 	cc -o $@ $<
 
 $(EBINDIR)/%.beam: $(SRCDIR)/%.erl
-	@mkdir -p $(EBINDIR)
+	@$(MKDIR_P) $(EBINDIR)
 	$(ERLC) -I $(INCDIR) -o $(EBINDIR) $(COMP_OPTS) $(ERLCFLAGS) $<
 
 %.erl: %.xrl
@@ -214,7 +216,7 @@ $(DOCDIR)/%.txt: $(MANDIR)/%.7
 	groff -t -e -mandoc -Tutf8 -Kutf8 $< | col -bx > $@
 
 $(PDFDIR):
-	@mkdir -p $(PDFDIR)
+	@$(MKDIR_P) $(PDFDIR)
 
 docs-pdf: $(PDFDIR) \
 	$(addprefix $(PDFDIR)/, $(PDF1S)) \
@@ -231,7 +233,7 @@ $(PDFDIR)/%.pdf: $(DOCSRC)/%.7.md
 	pandoc -f markdown --latex-engine=xelatex -o $@ $<
 
 $(EPUBDIR):
-	@mkdir -p $(EPUBDIR)
+	@$(MKDIR_P) $(EPUBDIR)
 
 docs-epub: $(EPUBDIR) \
 	$(addprefix $(EPUBDIR)/, $(EPUB1S)) \
@@ -247,8 +249,10 @@ $(EPUBDIR)/%.epub: $(DOCSRC)/%.3.md
 $(EPUBDIR)/%.epub: $(DOCSRC)/%.7.md
 	pandoc -f markdown -t epub -o $@ $<
 
-install-man:
-	$(INSTALL_DIR) $(MANINSTDIR)/man{1,3,7}
+$(MANINSTDIR)/man%:
+	mkdir -p $@
+
+install-man: $(MANINSTDIR)/man1 $(MANINSTDIR)/man3 $(MANINSTDIR)/man7
 	$(INSTALL_DATA) $(MANDIR)/*.1 $(MANINSTDIR)/man1/
 	$(INSTALL_DATA) $(MANDIR)/*.3 $(MANINSTDIR)/man3/
 	$(INSTALL_DATA) $(MANDIR)/*.7 $(MANINSTDIR)/man7/

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ comp_opts.mk:
 
 -include comp_opts.mk
 
+$(BINDIR)/lfe%:
+	$(INSTALL_BIN) $@ $(DESTBINDIR)
+
 install: compile install-man
 	rm -Rf $(DESTEBINDIR)
 	$(INSTALL_DIR) $(DESTEBINDIR)
@@ -123,7 +126,7 @@ install: compile install-man
 	$(INSTALL_DATA) $(addprefix $(EBINDIR)/, $(EBINS)) $(DESTEBINDIR)
 	$(INSTALL_DATA) $(addprefix $(EBINDIR)/, $(LBINS)) $(DESTEBINDIR)
 	$(INSTALL_DIR) $(DESTBINDIR)
-	$(INSTALL_BIN) $(BINDIR)/lfe{,c,doc,script} $(DESTBINDIR)
+	$(MAKE) $(BINDIR)/lfe $(BINDIR)/lfec $(BINDIR)/lfedoc $(BINDIR)/lfescript
 	ln -sf $(DESTBINDIR)/* $(PREFIX)/bin/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ DESTBINDIR := $(DESTLIBDIR)/$(BINDIR)
 VPATH = $(SRCDIR)
 
 MKDIR_P = mkdir -p
+MANDB = $(shell which mandb)
 
 ERLCFLAGS = -W1
 ERLC = erlc
@@ -88,7 +89,7 @@ $(EBINDIR)/%.beam: $(LSRCDIR)/%.lfe
 
 all: compile
 
-.PHONY: compile erlc-compile lfec-compile erlc-lfec emacs install docs clean docker-build docker-push docker
+.PHONY: compile erlc-compile lfec-compile erlc-lfec emacs install docs clean docker-build docker-push docker update-mandb
 
 compile: comp_opts.mk
 	$(MAKE) $(MFLAGS) erlc-lfec
@@ -253,12 +254,20 @@ $(EPUBDIR)/%.epub: $(DOCSRC)/%.7.md
 	pandoc -f markdown -t epub -o $@ $<
 
 $(MANINSTDIR)/man%:
-	mkdir -p $@
+	@$(MKDIR_P) -p $@
 
+ifeq (,$(findstring mandb,$(MANDB)))
 install-man: $(MANINSTDIR)/man1 $(MANINSTDIR)/man3 $(MANINSTDIR)/man7
+else
+install-man: $(MANINSTDIR)/man1 $(MANINSTDIR)/man3 $(MANINSTDIR)/man7 update-mandb
+endif
 	$(INSTALL_DATA) $(MANDIR)/*.1 $(MANINSTDIR)/man1/
 	$(INSTALL_DATA) $(MANDIR)/*.3 $(MANINSTDIR)/man3/
 	$(INSTALL_DATA) $(MANDIR)/*.7 $(MANINSTDIR)/man7/
+
+update-mandb:
+	@echo "Updating man page database ..."
+	$(MANDB) $(MANINSTDIR)
 
 # Targets for working with Docker
 docker-build:


### PR DESCRIPTION
This contains fixes for LFE installs on machines whose gnumake doesn't use a shell that supports curly brace expansion.

Additionally, it improves upon the man page installation by updating the man page database if `mandb` is in the `PATH`.

Fixes #326 