### PR TITLE
replace c:i/1 with c:i/3

### DIFF
--- a/src/lfe_shell.erl
+++ b/src/lfe_shell.erl
@@ -794,7 +794,7 @@ help() ->
 
 i() -> c:i().
 
-i(Pids) -> c:i(Pids).
+i(X, Y, Z) -> c:i(X, Y, Z).
 
 %% l(Modules) -> ok.
 %%  Load the modules.


### PR DESCRIPTION
I can't find documentation about c:i/1, so I assume otp made some changes.