### PR TITLE
Add install-include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ INSTALL_DIR = $(INSTALL) -m755 -d
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_BIN = $(INSTALL) -m755
 DESTLIBDIR := $(PREFIX)/lib/lfe
+DESTINCDIR := $(DESTLIBDIR)/$(INCDIR)
 DESTEBINDIR := $(DESTLIBDIR)/$(EBINDIR)
 DESTBINDIR := $(DESTLIBDIR)/$(BINDIR)
 
@@ -116,7 +117,11 @@ comp_opts.mk:
 
 -include comp_opts.mk
 
-install: compile install-beam install-bin install-man
+install: compile install-include install-beam install-bin install-man
+
+install-include:
+	$(INSTALL_DIR) $(DESTINCDIR)
+	$(INSTALL_DATA) $(INCDIR)/* $(DESTINCDIR)
 
 install-beam:
 	rm -Rf $(DESTEBINDIR)


### PR DESCRIPTION
This PR cherry-picks an old bug-fix from @yurrriq.

Original PR is here: https://github.com/rvirding/lfe/pull/341

Description from that PR is below ...

----
#### Before

```lfe
lfe> (progn (include-lib "lfe/include/clj.lfe") (-> 2 (+ 2)))
1: error expanding (include-lib "lfe/include/clj.lfe"): #(none file enoent)
error
```

#### After

```lfe
lfe> (progn (include-lib "lfe/include/clj.lfe") (-> 2 (+ 2)))
4
```
