### PR TITLE
Remove duplicate entries from EBINS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ install-beam:
 	$(INSTALL_DIR) $(DESTEBINDIR)
 	$(INSTALL_DATA) \
 		$(EBINDIR)/$(APP_DEF) \
-		$(addprefix $(EBINDIR)/, $(EBINS)) \
+		$$(printf '%s\n' $(addprefix $(EBINDIR)/, $(EBINS)) | sort -u) \
 		$(addprefix $(EBINDIR)/, $(LBINS)) \
 		$(DESTEBINDIR)
 


### PR DESCRIPTION
Note: this is a cherry-pick from this old PR by @beji (which was too old to merge):
* https://github.com/rvirding/lfe/pull/343

Commit message:

lfe_scan.xrl will get compiled to lfe_scan.erl during make compile,
which in turn will be compiled to lfe_scan.beam.
Since EBINS contains all the .erl and .xrl files with the ending
replaced by .beam it will contain lfe_scan.beam twice when executing
make install which may cause an error on execution.


Original PR description follows ...

----

Hi,
as mentioned on #342 make install fails on my gentoo system because make install tries to install lfe_scan.beam twice.
During the whole compilation magic src/lfe_scan.xrl will get turned into src/lfe_scan.erl . As EBINS is essentially a list of all .erl, .xrl and .yrl files with the endings replaced by .beam this results in the problem that EBINS will contain lfe_scan.beam twice as this name is generated from both the .xrl and the .erl file. As this problem seems to affect the install target I tried not to mess with anything else (I don't know a lot about make).

This fix is kinda ugly but it resolves the issue for me. Not sure if this will work well on other systems but it might be worth a shot.