### PR TITLE
Don't display banner with -noshell or -nobanner CLI args.

### DIFF
--- a/src/lfe_shell.erl
+++ b/src/lfe_shell.erl
@@ -128,7 +128,7 @@ server() ->
 
 server(St) ->
     process_flag(trap_exit, true),              %Must trap exists
-    io:put_chars(make_banner()),
+    display_banner(),
     %% Set shell io to use LFE expand in edlin, ignore error.
     io:setopts([{expand_fun,fun (B) -> lfe_edlin_expand:expand(B) end}]),
     Eval = start_eval(St),                      %Start an evaluator
@@ -258,6 +258,18 @@ make_banner() ->
        ?GRN("   \\     ") ++ ?RED("l") ++ ?GRN("    |_/") ++  "    |\n" ++
        ?GRN("    \\   ") ++ ?RED("r") ++ ?GRN("     /") ++  "      |   LFE v~s ~s\n" ++
        ?GRN("     `-") ++ ?RED("E") ++ ?GRN("___.-'") ++ "\n\n", [get_lfe_version(), get_abort_message()])].
+
+display_banner() ->
+    %% When LFE is called with -noshell, we want to skip the banner. Also, there may be
+    %% circumstances where the shell is desired, but the banner needs to be disabled,
+    %% thus we want to support both use cases.
+    case init:get_argument(noshell) of
+        error -> case init:get_argument(nobanner) of
+                    error -> io:put_chars(make_banner());
+                    _ -> false
+                 end;
+        _ -> false
+    end.
 
 get_abort_message() ->
     %% We can update this later to check for env variable settings for


### PR DESCRIPTION
Fixes #369 

With this change users can now do the following:

```
$ ./bin/lfe -nobanner
Erlang/OTP 22 [erts-10.6.2] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [hipe] [dtrace]

lfe>
```

(witness no banner is displayed).