### PR TITLE
Allow customization of how lfe is launched

### DIFF
--- a/doc/src/lfe_clj.3.md
+++ b/doc/src/lfe_clj.3.md
@@ -10,7 +10,7 @@ clj - LFE Clojure interface library.
 
 # SYNOPSIS
 
-This module provides Clojure-inpired functions and macros for use in LFE.
+This module provides Clojure-inspired functions and macros for use in LFE.
 
 
 # EXPORTS
@@ -593,7 +593,7 @@ Equivalent to `(next func start 1)`.
 Return a nullary function that returns a cons cell with `start` as the head and
 a nullary function, `(next func (funcall func start step) step)` as the tail.
 The result can be treated as a (possibly infinite) lazy list, which only
-computes subseqeuent values as needed.
+computes subsequent values as needed.
 
 **(lazy-seq seq)**
 
@@ -653,7 +653,7 @@ Equivalent to `(partition n step () lst)`.
 
 Return a list of lists of `n` items each, at offsets `step` apart.
 Use the elements of `pad` as necessary to complete the last partition up to `n`
-elements. In case there are not enough padding elements, return a parition with
+elements. In case there are not enough padding elements, return a partition with
 less than `n` items.
 
 **(partition-all n lst)**

--- a/doc/src/lfe_comp.3.md
+++ b/doc/src/lfe_comp.3.md
@@ -123,7 +123,7 @@ ModErr = {error,Errors,Warnings}
 Compile the forms as an LFE module returning a binary. This
 function takes the same options as ``lfe_comp:file/1/2``. When
 generating Errors and Warnings the "line number" is the index
-of the form in which the error occured.
+of the form in which the error occurred.
 
 **format_error(Error) -> Chars**
 

--- a/doc/src/lfe_guide.7.md
+++ b/doc/src/lfe_guide.7.md
@@ -7,7 +7,7 @@
 
 lfe_guide - Lisp Flavoured Erlang User Guide
 
-# SYNPOSIS
+# SYNOPSIS
 
 Note: {{ ... }} is used to denote optional syntax.
 
@@ -100,7 +100,7 @@ numbers:
 1.0 +1.0 -1.0 1.0e10 1.111e-10
 ```
 
-The one thing to watch out for is that you cannot omit the the part
+The one thing to watch out for is that you cannot omit the part
 before or after the decimal point if it is zero.  E.g. the following are
 not valid forms: ``100.`` or ``.125``.
 
@@ -125,7 +125,7 @@ e.g. ``"\x61;\x62;\x63;"`` is a complicated way of writing ``"abc"``.  This can
 be convenient when writing Unicode letters not easily typeable or
 viewable with regular fonts.  E.g. ``"Cat: \\x1f639;"`` might be easier to
 type (and view on output devices without a Unicode font) then typing the
-actual unicode letter.
+actual Unicode letter.
 
 
 ### Binary Strings
@@ -226,7 +226,7 @@ somewhat surprisingly ``123foo`` and ``1.23e4extra`` (but note that illegal
 digits don't make a number a symbol when using the explicit number base
 notation, e.g. ``#b10foo`` gives an error).
 
-<!-- 
+<!--
 Symbol names can contain a surprising breadth or characters:
 
 ```
@@ -354,8 +354,8 @@ while it reads the expression and then be effectively ``2``.
 (define-function name meta-data lambda|match-lambda)
 (define-macro name meta-data lambda|match-lambda)
 
-(define-type type defintion)
-(define-opaque-type type defintion)
+(define-type type definition)
+(define-opaque-type type definition)
 (define-function-spec func spec)
 ```
 
@@ -566,8 +566,8 @@ following order within a module, outermost to innermost:
 
 This means that it is perfectly legal to shadow BIFs by imports,
 BIFs/imports by top-level functions and BIFs/imports/top-level by
-``fletrec``s. In this respect there is nothing special about BIfs, they
-just behave as prefined imported functions, a whopping big ``(import
+``fletrec``s. In this respect there is nothing special about BIFs, they
+just behave as predefined imported functions, a whopping big ``(import
 (from erlang ...))``. EXCEPT that we know about guard BIFs and
 expression BIFs. If you want a private version of ``spawn`` then define
 it, there will be no warnings.
@@ -589,7 +589,7 @@ attributes are:
 
 The valid meta data is ``(type typedef ...)``, ``(opaque typedef ...)``,
 ``(spec function-spec ...)`` and ``(record record-def ...)``.
-Each can take multuiple definitions in one meta form.
+Each can take multiple definitions in one meta form.
 
 Attributes declarations have the syntax ``(attribute value-1 ...)``
 where the attribute value is a list off the values in the declaration
@@ -612,7 +612,7 @@ To simplify defining modules there is a predefined macro:
 We can have multiple export and import attributes within module
 declaration. The ``(export all)`` attribute is allowed together with
 other export attributes and overrides them. Other attributes which are
-not recognised by the compiler are allowed and are simply passed on to
+not recognized by the compiler are allowed and are simply passed on to
 the module and can be accessed with the ``module_info/0-1`` functions.
 
 In the ``import`` attribute the ``(from mod (f1 2) ...)`` means that
@@ -724,7 +724,7 @@ which are called by macros can defined after the macro but must be
 defined before the macro is used.
 
 Scheme's syntax rules are an easy way to define macros where the body
-is just a simple expansion. The are implmeneted the the module `scm`
+is just a simple expansion. The are implemented the the module `scm`
 and are supported with ``scm:define-syntax`` and ``scm:let-syntax``
 and the equivalent ``scm:defsyntax`` and ``scm:syntaxlet``. Note that
 the patterns are only the arguments to the macro call and do not
@@ -994,7 +994,7 @@ To access maps there are the following forms:
 * ``(map-remove map key ... )`` -
   Remove the keys in the map.
 
-N.B. This syntax for processing maps has stablized but may change in
+N.B. This syntax for processing maps has stabilized but may change in
 the future!
 
 There are also alternate short forms ``msiz``, ``mref``, ``mset``,
@@ -1136,7 +1136,7 @@ The following more or less standard lisp functions are predefined:
 (<comp_op> expr ...)
 ```
 
-The standard arithmentic operators, + - * /, and
+The standard arithmetic operators, + - * /, and
 comparison operators, > >= < =< == /= =:= =/= , can take
 multiple arguments the same as their standard lisp
 counterparts. This is still experimental and implemented
@@ -1163,7 +1163,7 @@ The standard association list functions.
 (subst-if-not new test tree)
 (sublis alist tree)
 ```
-The standard substituition functions.
+The standard substitution functions.
 
 ```
 (macroexpand-1 expr {{environment}})
@@ -1216,7 +1216,7 @@ LFE provides the module cl which contains the following functions
 which closely mirror functions defined in the Common Lisp
 Hyperspec. Note that the following functions use zero-based indices,
 like Common Lisp (unlike Erlang, which start at index '1'). A major
-difference between the LFE versions and the Common Lisp versions of 
+difference between the LFE versions and the Common Lisp versions of
 these functions is that the boolean values are
 the LFE `'true` and `'false`. Otherwise the definitions closely follow the
 CL definitions and won't be documented here.
@@ -1312,7 +1312,7 @@ cl:type-of  object
 cl:coerce  object  type
 ```
 
-Furthmore, there is an include file which developers may which to utilize in
+Furthermore, there is an include file which developers may which to utilize in
 their LFE programs: `(include-lib "lfe/include/cl.lfe")`. Currently this offers
 Common Lisp predicates, but may include other useful macros and functions in
 the future. The provided predicate macros wrap the various `is_*` Erlang
@@ -1429,7 +1429,7 @@ Other:
 (clj:if ...)
 ```
 
-Most of the above mentioned macros are avaialble in the `clj` include file,
+Most of the above mentioned macros are available in the `clj` include file,
 the use of which allows developers to forego the `clj:` prefix in calls:
 
 ```

--- a/doc/src/version_history.md
+++ b/doc/src/version_history.md
@@ -117,7 +117,7 @@ Parameterized modules.
 Added ``(export all)`` attribute to module definition.
 
 Added new records which allow giving default values as in vanilla Erlang.
-Records are still compatible with vanilla Erlang but now more pratical
+Records are still compatible with vanilla Erlang but now more practical
 to use. NOTE this change is not backwards compatible as syntax for
 ``(make- ...)`` and ``(match- ...)`` have changed. Also added general
 multiple ``(set- ...)`` macro.
@@ -126,13 +126,13 @@ multiple ``(set- ...)`` macro.
 functions to be defined when compiling the forms. These are useful for
 more complex macros.
 
-Better and more documention. The documentation is still normal text
+Better and more documentation. The documentation is still normal text
 files as Edoc and are not in agreement on how things should work.
 
 ## v0.3
 
 This is the first version with the modified internal core forms and
-macro intefaces for the new CL-inspired style and the older Scheme-inspired
+macro interfaces for the new CL-inspired style and the older Scheme-inspired
 style.
 
 Two new modules have been added:
@@ -148,7 +148,7 @@ NOTE order of commands important, must be ``-noshell -noinput``! Add
 ``-pa`` to find modules if necessary.
 
 ``lfe_gen`` is a trial interface for using LFE for dynamic code
-generation. LFE is much easier to generate as an Erkang list than
+generation. LFE is much easier to generate as an Erlang list than
 Erlang forms. This module helps with defining and compiling a module. Note,
 that while it works, this module is very experimental and may change.
 
@@ -161,7 +161,7 @@ name space. The reason for this change is that the ErlangVM does
 keep variables and functions separate and while Core Erlang tries to
 hide this fact it does not fully succeed. In fact, it is actually
 impossible to do this given Erlang's property of being able to have
-many functions of the same name but with different arites.
+many functions of the same name but with different arities.
 
 While this is not as elegant and forces the use of funcall to call
 functions bound to variables it works better.
@@ -187,13 +187,13 @@ or binary. For example:
 ```cl
 
   (tuple 'ok a b)
-  ; this is eqivalent to {ok,A,B}
+  ; this is equivalent to {ok,A,B}
 
   #('ok a b)
-  ; this is eqivalent to {[quote,ok],a,b}
+  ; this is equivalent to {[quote,ok],a,b}
 
   (binary (f float (size 32)) (rest binary))
-  ; this is eqivalent to <<F:32/float,Rest:binary>>
+  ; this is equivalent to <<F:32/float,Rest:binary>>
 
 ```
 
@@ -213,7 +213,7 @@ the file are also available.
 
 It is not yet possible to define functions/macros in the shell but
 that should use soon be possible. You should also then be able to do
-regurgítate which would write all the definitions out to a file.
+regurgitate which would write all the definitions out to a file.
 
 Running a shell other than the standard erlang one is a bit
 difficult so I have included a patched version of user_drv.erl from
@@ -237,4 +237,3 @@ to test linter.
 There is now a lisp prettyprinter in ``lfe_io``. Unfortunately the io
 functions in ``lfe_io`` are not always obviously named from a lisp
 viewpoint.
-

--- a/emacs/inferior-lfe.el
+++ b/emacs/inferior-lfe.el
@@ -43,13 +43,19 @@
 (define-key lfe-mode-map "\C-c\C-z" 'switch-to-lfe)
 
 ;; (defvar inferior-lfe-program "lfe -pa /Users/rv/erlang/lfe/ebin -env TERM vt100"
-(defvar inferior-lfe-program "lfe"
-  "*Program name for invoking an inferior LFE in Inferior LFE mode.")
+(defcustom inferior-lfe-program "lfe"
+  "*Program name for invoking an inferior LFE in Inferior LFE mode."
+  :group 'lfe
+  :type 'string)
 
-(defvar inferior-lfe-program-options '("-pa" "/Users/rv/erlang/lfe/ebin")
+(defcustom inferior-lfe-program-options '("-pa" "/Users/rv/erlang/lfe/ebin")
   "*The options used when activating the LFE shell.
 
-This must be a list of strings.")
+This must be a list of strings.
+You may add the following command line options:
+- \"-nobanner\"."
+  :group 'lfe
+  :type '(repeat string))
 
 (defvar inferior-lfe-prompt "^[^>]*>+ *"
   "*Regexp to recognise prompts in the Inferior LFE mode.")


### PR DESCRIPTION
Convert inferior-lfe-program and inferior-lfe-program-options into defcustom forms.
- Provide user's ability to customize how lfe is started using Emacs easy customization mechanism.
- Nothing removed, it's still possible to set the values inside the init file.
- Identify '-nobanner' as a possible option to place in the list.