### PR TITLE
Task/update versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    name: Build on OTP ${{ matrix.otp_version }} / ${{ matrix.os }}
+    name: Newer builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -26,8 +26,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Erlang version check
       run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+    - name: Download rebar3
+      run: wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3-version }}/rebar3 && chmod 755 ./rebar3
     - name: Rebar version check
-      run: rebar3 -v
+      run: ./rebar3 -v
     - name: Compile (with make)
       run: make compile
     - name: Install
@@ -35,22 +37,22 @@ jobs:
     - name: Clean make-based Build
       run: make clean
     - name: Compile (with rebar3)
-      run: rebar3 compile
+      run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: rebar3 as test do compile,eunit,eunit
+      run: ./rebar3 as test do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
       #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
       #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
-      run: rebar3 as test proper -n 20
+      run: ./rebar3 as test proper -n 20
     - name: CT Suite Tests
-      run: rebar3 as test ct
+      run: ./rebar3 as test ct
 
   older-builds:
-    name: Build on OTP ${{ matrix.otp_version }} / ${{ matrix.os }}
-    runs-on: ubuntu-latest
+    name: Older builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
+    runs-on: ubuntu-16.04
 
     strategy:
       fail-fast: false
@@ -66,8 +68,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Erlang version check
       run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+    - name: Download rebar3
+      run: wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3-version }}/rebar3 && chmod 755 ./rebar3
     - name: Rebar version check
-      run: rebar3 -v
+      run: ./rebar3 -v
     - name: Compile (with make)
       run: make compile
     - name: Install
@@ -75,15 +79,15 @@ jobs:
     - name: Clean make-based Build
       run: make clean
     - name: Compile (with rebar3)
-      run: rebar3 compile
+      run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: rebar3 as test_older do compile,eunit,eunit
+      run: ./rebar3 as test_older do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
       #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
       #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
-      run: rebar3 as test_older proper -n 20
+      run: ./rebar3 as test_older proper -n 20
     - name: CT Suite Tests
-      run: rebar3 as test_older ct
+      run: ./rebar3 as test_older ct

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,14 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: [19, 20, 21, 22, 23, 24]
-        os: [ubuntu-latest]
+        otp-version: ['22', '23', '24']
+        rebar3-version: ['3.16.1']
+        os: ['ubuntu-latest']
 
     container:
-      image: erlang:${{ matrix.otp_version }}
+      image: erlang:${{ matrix.otp-version }}
 
     steps:
     - uses: actions/checkout@v2
+    - name: Erlang version check
+      run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+    - name: Rebar version check
+      run: rebar3 -v
     - name: Compile (with make)
       run: make compile
     - name: Install
@@ -42,3 +47,43 @@ jobs:
       run: rebar3 as test proper -n 20
     - name: CT Suite Tests
       run: rebar3 as test ct
+
+  older-builds:
+    name: Build on OTP ${{ matrix.otp_version }} / ${{ matrix.os }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        otp-version: ['19', '20', '21']
+        rebar3-version: ['3.14.4']
+        os: ['ubuntu-16.04']
+
+    container:
+      image: erlang:${{ matrix.otp-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Erlang version check
+      run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+    - name: Rebar version check
+      run: rebar3 -v
+    - name: Compile (with make)
+      run: make compile
+    - name: Install
+      run: make install PREFIX=$(mktemp -d)
+    - name: Clean make-based Build
+      run: make clean
+    - name: Compile (with rebar3)
+      run: rebar3 compile
+    - name: Run eunit Tests
+      # XXX for some reason, the first pass of eunit doesn't run the tests?!
+      run: rebar3 as test_older do compile,eunit,eunit
+    - name: Run proper Tests
+      # XXX this is a hack; we're getting VM crashes due to atom-table filling
+      #     for the default test count of '100' -- note, however:
+      #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
+      #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
+      run: rebar3 as test_older proper -n 20
+    - name: CT Suite Tests
+      run: rebar3 as test_older ct

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,9 +2,9 @@ name: ci/cd
 
 on:
   push:
-    branches: [ master, release/*, develop]
+    branches: [ master, release/*, task/*, feature/*, develop]
   pull_request:
-    branches: [ master, release/*, develop]
+    branches: [ master, release/*, task/*, feature/*, develop]
 
 jobs:
 
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: [19, 20, 21, 22, 23]
+        otp_version: [19, 20, 21, 22, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,13 +43,30 @@ jobs:
       run: ./rebar3 as test_newer proper -n 20
     - name: CT Suite Tests
       run: ./rebar3 as test_newer ct
-    - name: Clean-up
-      run: make clean
+
+  installs:
+    name: Newer installs - OTP ${{ matrix.otp-version }} / ${{ matrix.os }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        otp-version: ['22', '23', '24']
+        os: ['ubuntu-latest']
+
+    container:
+      image: erlang:${{ matrix.otp-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Erlang version check
+      run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
     - name: Compile (with make)
       run: make compile
     - name: Install
       run: make install PREFIX=$(mktemp -d)
 
+      
   older-builds:
     name: Older builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
     runs-on: ubuntu-16.04
@@ -85,8 +102,25 @@ jobs:
       run: ./rebar3 as test_older proper -n 20
     - name: CT Suite Tests
       run: ./rebar3 as test_older ct
-    - name: Clean-up
-      run: make clean
+
+  older-installs:
+    name: Older installs - OTP ${{ matrix.otp-version }} / ${{ matrix.os }}
+    runs-on: ubuntu-16.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        otp-version: ['19', '20', '21']
+        rebar3-version: ['3.14.4']
+        os: ['ubuntu-16.04']
+
+    container:
+      image: erlang:${{ matrix.otp-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Erlang version check
+      run: erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
     - name: Compile (with make)
       run: make compile
     - name: Install

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build:
+  builds:
     name: Newer builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
     runs-on: ubuntu-latest
 
@@ -34,18 +34,19 @@ jobs:
       run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: ./rebar3 as test_newer do compile,eunit,eunit
+      run: ./rebar3 as test do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
       #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
       #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
-      run: ./rebar3 as test_newer proper -n 20
+      run: ./rebar3 as test proper -n 20
     - name: CT Suite Tests
-      run: ./rebar3 as test_newer ct
+      run: ./rebar3 as test ct
 
   installs:
     name: Newer installs - OTP ${{ matrix.otp-version }} / ${{ matrix.os }}
+    needs: builds
     runs-on: ubuntu-latest
 
     strategy:
@@ -69,14 +70,14 @@ jobs:
       
   older-builds:
     name: Older builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
       matrix:
         otp-version: ['19', '20', '21']
         rebar3-version: ['3.14.4']
-        os: ['ubuntu-16.04']
+        os: ['ubuntu-18.04']
 
     container:
       image: erlang:${{ matrix.otp-version }}
@@ -93,26 +94,27 @@ jobs:
       run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: rm rebar.lock && DEBUG=1 ./rebar3 as test_older do compile,eunit,eunit
+      run: rm rebar.lock && DEBUG=1 ./rebar3 as test do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
       #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
       #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
-      run: ./rebar3 as test_older proper -n 20
+      run: ./rebar3 as test proper -n 20
     - name: CT Suite Tests
-      run: ./rebar3 as test_older ct
+      run: ./rebar3 as test ct
 
   older-installs:
     name: Older installs - OTP ${{ matrix.otp-version }} / ${{ matrix.os }}
-    runs-on: ubuntu-16.04
+    needs: older-builds
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
       matrix:
         otp-version: ['19', '20', '21']
         rebar3-version: ['3.14.4']
-        os: ['ubuntu-16.04']
+        os: ['ubuntu-18.04']
 
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,25 +30,25 @@ jobs:
       run: wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3-version }}/rebar3 && chmod 755 ./rebar3
     - name: Rebar version check
       run: ./rebar3 -v
-    - name: Compile (with make)
-      run: make compile
-    - name: Install
-      run: make install PREFIX=$(mktemp -d)
-    - name: Clean make-based Build
-      run: make clean
     - name: Compile (with rebar3)
       run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: ./rebar3 as test do compile,eunit,eunit
+      run: ./rebar3 as test_newer do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
       #     * 'prop_lfe_docs:prop_define_lambda' works just fine with 100 tests
       #     * 'prop_lfe_docs:prop_define_match' is the one that crashes the VM
-      run: ./rebar3 as test proper -n 20
+      run: ./rebar3 as test_newer proper -n 20
     - name: CT Suite Tests
-      run: ./rebar3 as test ct
+      run: ./rebar3 as test_newer ct
+    - name: Clean-up
+      run: make clean
+    - name: Compile (with make)
+      run: make compile
+    - name: Install
+      run: make install PREFIX=$(mktemp -d)
 
   older-builds:
     name: Older builds - OTP ${{ matrix.otp-version }} (rebar3 ${{ matrix.rebar3-version }}) / ${{ matrix.os }}
@@ -72,17 +72,11 @@ jobs:
       run: wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3-version }}/rebar3 && chmod 755 ./rebar3
     - name: Rebar version check
       run: ./rebar3 -v
-    - name: Compile (with make)
-      run: make compile
-    - name: Install
-      run: make install PREFIX=$(mktemp -d)
-    - name: Clean make-based Build
-      run: make clean
     - name: Compile (with rebar3)
       run: ./rebar3 compile
     - name: Run eunit Tests
       # XXX for some reason, the first pass of eunit doesn't run the tests?!
-      run: ./rebar3 as test_older do compile,eunit,eunit
+      run: rm rebar.lock && DEBUG=1 ./rebar3 as test_older do compile,eunit,eunit
     - name: Run proper Tests
       # XXX this is a hack; we're getting VM crashes due to atom-table filling
       #     for the default test count of '100' -- note, however:
@@ -91,3 +85,9 @@ jobs:
       run: ./rebar3 as test_older proper -n 20
     - name: CT Suite Tests
       run: ./rebar3 as test_older ct
+    - name: Clean-up
+      run: make clean
+    - name: Compile (with make)
+      run: make compile
+    - name: Install
+      run: make install PREFIX=$(mktemp -d)

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,11 @@
 
 {erl_opts, [debug_info]}.
 
-{profiles, [{test, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.4"}}}]},
-                    {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
-                    {src_dirs, ["src", "test"]}]},
-            {test_older, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}]},
+{profiles, [{test_newer, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.4"}}}]},
                           {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
+                          {src_dirs, ["src", "test"]}]},
+            {test_older, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}]},
+                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.0"}}}]},
                           {src_dirs, ["src", "test"]}]},
             {dialyzer, []}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {profiles, [{test_newer, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.4"}}}]},
                           {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
                           {src_dirs, ["src", "test"]}]},
-            {test_older, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}]},
+            {test_older, [{deps, [{proper, "1.3.0"}]},
                           {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.0"}}}]},
                           {src_dirs, ["src", "test"]}]},
             {dialyzer, []}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,12 @@
 
 {erl_opts, [debug_info]}.
 
-{profiles, [{test, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}]},
-                    {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.0"}}}]},
+{profiles, [{test, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.4"}}}]},
+                    {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
                     {src_dirs, ["src", "test"]}]},
+            {test_older, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}]},
+                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
+                          {src_dirs, ["src", "test"]}]},
             {dialyzer, []}]}.
 
 {pre_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", ct,

--- a/rebar.config
+++ b/rebar.config
@@ -2,12 +2,11 @@
 
 {erl_opts, [debug_info]}.
 
-{profiles, [{test_newer, [{deps, [{proper, {git, "https://github.com/proper-testing/proper", {tag, "v1.4"}}}]},
-                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
-                          {src_dirs, ["src", "test"]}]},
-            {test_older, [{deps, [{proper, "1.3.0"}]},
-                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
-                          {src_dirs, ["src", "test"]}]},
+%% IMPORTANT! Versions of proper are calculated dynamically in the 'rebar.config.script' file, at the end;
+%%            DO NOT set/change the proper version here!
+{profiles, [{test, [{deps, [proper]},
+                    {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
+                    {src_dirs, ["src", "test"]}]},
             {dialyzer, []}]}.
 
 {pre_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", ct,

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
                           {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
                           {src_dirs, ["src", "test"]}]},
             {test_older, [{deps, [{proper, "1.3.0"}]},
-                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.0"}}}]},
+                          {plugins, [{rebar3_proper, {git, "https://github.com/ferd/rebar3_proper", {tag, "0.12.1"}}}]},
                           {src_dirs, ["src", "test"]}]},
             {dialyzer, []}]}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -85,10 +85,10 @@ Conf1 = case lists:keyfind(erl_opts, 1, Conf0) of
 
 %% Get the proper dep we will add to profiles-test-deps.
 
-Prop = if 
-    Version =< "17" -> {proper,"1.1.1-beta"};
-    Version =< "21" -> {proper,"1.3.0"};
-    Version =< "23" -> {proper,"1.4.0"};
+Prop = if
+    Version =< "17" -> {proper, "1.1.1-beta"};
+    Version =< "21" -> {proper, "1.3.0"};
+    Version =< "23" -> {proper, "1.4.0"};
     true -> proper
     end,
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -85,9 +85,12 @@ Conf1 = case lists:keyfind(erl_opts, 1, Conf0) of
 
 %% Get the proper dep we will add to profiles-test-deps.
 
-Prop = if Version >= "18" -> proper;            %Take the latest one.
-          true -> {proper,"1.1.1-beta"}
-       end,
+Prop = if 
+    Version =< "17" -> {proper,"1.1.1-beta"};
+    Version =< "21" -> {proper,"1.3.0"};
+    Version =< "23" -> {proper,"1.4.0"};
+    true -> proper
+    end,
 
 %% Ensure we have set the right value of proper dep.
 


### PR DESCRIPTION
We had some issues with Erlang 19 and the dep `proper`, and also we were missing Erlang 24 in CI/CD. These have all been addressed, now :-) 

Of particular note:
* Turns out the version of proper is set dynamically in `rebar.config.script` -- this has now been updated with the various versions we've used/need.
* The `rebar.config` file has been updated with "WARNING" comments :-) (letting developers know where to set the proper versions).
* While troubleshooting this, there were issues with the following, and they have all been addressed in this change:
  * using custom versions of `rebar3`; we now download specific versions in the build steps
  * using the latest `rebar3` for the latest Erlang releases; different versions of rebar are now used for older and newer Erlang releases
  * install steps taking place after the build-via-rebar steps; these have now been separated out into their own jobs
  * build and install running at the same time; these have now been set up to run sequentially
  * notices about deprecation of ubuntu-16.04; now the older Erlang releases use ubuntu-18.04 and the newer Erlang releases use ubuntu-latest

Here's the new look for builds:
![Screenshot 2021-06-01 at 4 55 36 PM](https://user-images.githubusercontent.com/894251/120503734-2a25fa80-c389-11eb-90a3-ef07ba067fdc.png)
