### PR TITLE
Hex.pm related updates and fixes.

### DIFF
--- a/src/lfe.app.src
+++ b/src/lfe.app.src
@@ -29,7 +29,8 @@
   {maintainers, ["Robert Virding"]},
   {licenses, ["Apache"]},
   {links, [{"Github", "https://github.com/lfe/lfe"},
-           {"Main site", "http://lfe.io/"},
-           {"Documentation", "http://docs.lfe.io/"}]},
-  {files, ["src", "include", "bin", "rebar.*", "README.md", "LICENSE"]}
+           {"Main site", "https://lfe.io/"},
+           {"Documentation", "https://lfe.io/use/#reference"}]},
+  {files, ["README.md", "LICENSE", "src", "c_src", "include", "bin",
+           "rebar.*",  "*akefile", "*.escript"]}
  ]}.


### PR DESCRIPTION
These changes were necessary to allow for Hex.pm users to compile LFE (the previous packages were missing `Makefile`, `Emakefile`, `get_comp_opts.escript`, and `c_src`).