### PR TITLE
Prevent comint prompt in emacs being pushed into comint-input-ring

### DIFF
--- a/emacs/inferior-lfe.el
+++ b/emacs/inferior-lfe.el
@@ -103,7 +103,7 @@ Return nil if `STR` matches `inferior-lfe-filter-regexp', otherwise t."
   (save-excursion
     (let ((end (point)))
       (backward-sexp)
-      (buffer-substring (point) end))))
+      (buffer-substring (max (point) (comint-line-beginning-position)) end))))
 
 ;;;###autoload
 (defun inferior-lfe (cmd)


### PR DESCRIPTION
I'm running emacs 26 and was surprised to find sometimes that the
"lfe> " input prompt of inferior-lfe appears in the REPL history, and 
it's read-only text so cannot be edited away. To reproduce (assuming 
M-n is bound to comint-next-input):

M-x run-lfe
'foo ; to produce an initial history entry
M-n
M-n

The first comint-next-input renders 'foo, the second renders lfe> ,
and it's read-only and can't be deleted, I tend to hit enter and get
back:

** exception error: symbol lfe> is unbound

Looking into fixing this, I found inf-clojure had the same issue some
time back:

https://github.com/oyvindstegard/inf-clojure/commit/ac08fdd2b58beb373567b29c189a1d0450575a42