### PR TITLE
Update Makefile to use host CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CSRCDIR = c_src
 LSRCDIR = src
 INCDIR = include
 EMACSDIR = emacs
+HOSTCC ?= $(CC)
 PREFIX ?= /usr/local
 INSTALL = install
 INSTALL_DIR = $(INSTALL) -m755 -d
@@ -72,7 +73,7 @@ ELCS = $(EMACSRCS:.el=.elc)
 .SUFFIXES: .erl .beam
 
 $(BINDIR)/%: $(CSRCDIR)/%.c
-	cc -o $@ $<
+	$(HOSTCC) -o $@ $<
 
 $(EBINDIR)/%.beam: $(SRCDIR)/%.erl
 	@$(INSTALL_DIR) $(EBINDIR)


### PR DESCRIPTION
Hi, I was able to get `lfe` working with GNU Guix and the changes in this PR simplified my Guix code a lot. I think it might also be good general practice for the `Makefile`.

What do you think?

Here's how my Guix package for `lfe` looks if this variable exists in the `Makefile`. Otherwise, I have to patch the `Makefile` which I can do but I thought this might be nice to add upstream.

This is how the Guix package looks when I have to patch cc:

https://issues.guix.gnu.org/60372

Closes #441

```scheme
;;; GNU Guix --- Functional package management for GNU
;;;
;;; Copyright © 2022 jgart <jgart@dismail.de>
;;; This file is not part of GNU Guix.
;;;
;;; GNU Guix is free software; you can redistribute it and/or modify it
;;; under the terms of the GNU General Public License as published by
;;; the Free Software Foundation; either version 3 of the License, or (at
;;; your option) any later version.
;;;
;;; GNU Guix is distributed in the hope that it will be useful, but
;;; WITHOUT ANY WARRANTY; without even the implied warranty of
;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
;;; GNU General Public License for more details.
;;;
;;; You should have received a copy of the GNU General Public License
;;; along with GNU Guix.  If not, see <http://www.gnu.org/licenses/>.

(define-module (guixrus packages lfe)
  #:use-module (guix build-system gnu)
  #:use-module (guix download)
  #:use-module (guix git-download)
  #:use-module ((guix licenses) #:prefix license:)
  #:use-module (guix packages)
  #:use-module (guix utils)
  #:use-module (guix gexp)
  #:use-module (guix build utils)
  #:use-module (gnu packages erlang)
  #:use-module (gnu packages))

(define-public lfe
  (package
    (name "lfe")
    (version "2.0.1")
    (source 
      (origin
       (method git-fetch)
       (uri (git-reference
             (url "https://github.com/lfe/lfe")
             (commit version)))
       (file-name (git-file-name name version))
       (sha256
        (base32 "0a5cfnk3021idvv4bv2lvnksjy9d0yyd13bnj793ks86j5f3hdv5"))))
    (build-system gnu-build-system)
    (propagated-inputs (list erlang))
    (arguments 
      (list #:tests? #f
            #:make-flags
            #~(list
               (string-append "PREFIX=" #$output)
               (string-append "CC=" #$(cc-for-target)))
            #:phases
            #~(modify-phases %standard-phases
                (delete 'configure))))
    (synopsis "Lisp Flavoured Erlang")
    (description
"@code{lfe}, Lisp Flavoured Erlang, is a lisp syntax front-end to the
Erlang compiler. Code produced with it is compatible with normal Erlang
code. An @code{lfe} evaluator and shell is also included.")
    (home-page "https://lfe.io/")
    (license license:asl2.0)))
```