### PR TITLE
Fix expansion for comparison macros for 3 or more arguments

### DIFF
--- a/src/lfe_macro.erl
+++ b/src/lfe_macro.erl
@@ -43,8 +43,7 @@
                   add_mbinding/3,is_mbound/2,get_mbinding/2]).
 
 -import(lists, [any/2,all/2,map/2,foldl/3,foldr/3,mapfoldl/3,
-                reverse/1,reverse/2,member/2,concat/1,
-                droplast/1,zip/2]).
+                reverse/1,reverse/2,member/2,concat/1]).
 
 -include("lfe.hrl").
 -include("lfe_comp.hrl").
@@ -1176,7 +1175,8 @@ exp_comp(As, Op, St0) ->
     {exp_let_star([Ls,exp_andalso(Ts)]),St1}.
 
 op_pairs(Ls, Op) ->
-    [exp_bif(Op, [V1,V2]) || {[V1,_],[V2,_]} <- zip(droplast(Ls), tl(Ls))].
+    Ps = lists:zip(lists:droplast(Ls),tl(Ls)),
+    [exp_bif(Op, [V1,V2]) || {[V1,_],[V2,_]} <- Ps].
 
 %% exp_nequal(Args, Op, State) -> {Exp,State}.
 %%  Expand not equal test strictly forcing evaluation of all

--- a/src/lfe_macro.erl
+++ b/src/lfe_macro.erl
@@ -1171,10 +1171,12 @@ exp_comp([A], _, St) ->            %Force evaluation
     {[progn,A,?Q(true)],St};
 exp_comp([A,B], Op, St) -> {exp_bif(Op, [A,B]),St};
 exp_comp(As, Op, St0) ->
-    {Vs,St1} = new_symbs(length(As), St0),
-    Vbs = [[V,E] || {V,E} <- zip(Vs, As)],
-    B = ['and'|[exp_bif(Op, [A,B]) || {A,B} <- zip(droplast(Vs), tl(Vs))]],
-    {['let',Vbs,B],St1}.
+    {Ls,St1} = exp_args(As, St0),
+    Ts = op_pairs(Ls, Op),
+    {exp_let_star([Ls,exp_andalso(Ts)]),St1}.
+
+op_pairs(Ls, Op) ->
+    [exp_bif(Op, [V1,V2]) || {[V1,_],[V2,_]} <- zip(droplast(Ls), tl(Ls))].
 
 %% exp_nequal(Args, Op, State) -> {Exp,State}.
 %%  Expand not equal test strictly forcing evaluation of all


### PR DESCRIPTION
The `exp_comp` function was updated to bind operands to variables and then compare the variables in successive pairs. Fixes #445.