### PR TITLE
Fix tests execution when using recent rebar3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ common-test:
 ct: common-test
 
 tests:
-	@rebar3 as test do compile,eunit,eunit,proper -n 20,ct
+	@rebar3 as test do compile,eunit,eunit,proper -n 20, ct
 
 #####################
 ### DOCUMENTATION ###


### PR DESCRIPTION
This fixes the following:

```
% rebar3 --version                                            
rebar 3.23.0 on Erlang/OTP 27 Erts 15.0
% make tests 
[...]
===> Compiling lfe
===> Testing prop_lfe_docs:prop_define_lambda()
Error: Unrecognized option: {task,[50,48,44,99,116]}.
===> Testing prop_lfe_docs:prop_define_match()
Error: Unrecognized option: {task,[50,48,44,99,116]}.
===> 
0/2 properties passed, 2 failed
===> Failed test cases:
prop_lfe_docs:prop_define_lambda() -> {error,
                                       {unrecognized_option,{task,"20,ct"}}}
prop_lfe_docs:prop_define_match() -> {error,
                                      {unrecognized_option,{task,"20,ct"}}}
make: *** [Makefile:199: tests] Error 1
```
