### PR TITLE
Ensure directory exists before writing the beam file...

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -71,6 +71,7 @@ Copts = Copts0 ++ AppendCopts(Version,
                                {"20",'HAS_CEIL'},
                                {"21",'NEW_STACKTRACE'},
                                {"23",'EEP48'},
+                               {"25",'HAS_ENSURE_DIR'},
                                {"27",'OTP27_MAYBE'}],
                               AppendCopts),
 


### PR DESCRIPTION
This happend when integrating with a mix project.

<img width="1440" height="259" alt="Screenshot 2025-11-03 at 19 55 19" src="https://github.com/user-attachments/assets/1b1365c9-db2f-427c-a23d-f2edc660fa99" />

From this image, the lfe path inside the `prod/lib` wasn't created.

Ensuring the directory is created fixed the problem, but not sure who should be responsible for creating the directory.

This patch fixes the lfe (tool) compilation. There is still issue on the rebar/mix integration to be addressed.

closes #489