### PR TITLE
Allow configure destination directory on make...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,13 @@ CFLAGS ?= -Wall -Wextra
 ifeq ($(OS_NAME),linux)
 	LDFLAGS ?= -Wl,--as-needed
 endif
-PREFIX ?= /usr/local
+DESTDIR ?= /usr/local
+PREFIX ?= $(DESTDIR)
 INSTALL = install
 INSTALL_DIR = $(INSTALL) -m755 -d
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_BIN = $(INSTALL) -m755
-DESTLIBDIR := $(PREFIX)/lib/lfe
+DESTLIBDIR := $(DESTDIR)/lib/lfe
 DESTINCDIR := $(DESTLIBDIR)/$(INCDIR)
 DESTEBINDIR := $(DESTLIBDIR)/$(EBINDIR)
 DESTBINDIR := $(DESTLIBDIR)/$(BINDIR)


### PR DESCRIPTION
As `PREFIX` was only used to install, this is ok.
This patch only helps to follow common make rules.

To make it right, we need to use `./configure` from autotools.

This way we would do the correct:

```sh
./configure PREFIX={build_path}
make install DESTDIR={destination_path}
```

#507