### PR TITLE
Bug/517/otp 28 user drv

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp-version: ['27', '26', '25', '24', '23', '22']
+        otp-version: ['29', '28', '27', '26', '25', '24', '23', '22']
         os: ['ubuntu-24.04']
 
     container:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp-version: ['28', '27', '26', '25', '24', '23', '22']
+        otp-version: ['29', '28', '27', '26', '25', '24', '23', '22']
         os: ['ubuntu-24.04']
 
     container:

--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,8 @@ eunit:
 proper:
 	@rebar3 as test do compile,proper -n 20
 
-common-test:
-	@rebar3 as test do compile,ct
+common-test: compile
+	@rebar3 as test ct
 
 ct: common-test
 

--- a/src/lfe_init.erl
+++ b/src/lfe_init.erl
@@ -53,21 +53,22 @@ start() ->
                {ok, [[R|_]]} -> list_to_atom(R);
                _Other -> ?DEFAULT_REPL
            end,
+    Rel = list_to_integer(OTPRelease),
     case collect_args(init:get_plain_arguments()) of
         {[],[]} ->                              %Run a shell
-            if OTPRelease >= "26" ->
-                    %% The new way 26 and later.
+            if Rel >= 26 ->
                     user_drv:start(#{initial_shell => {Repl,start,[]}});
                true ->
-                    %% The old way before 26.
                     user_drv:start(['tty_sl -c -e',{Repl,start,[]}])
             end;
         {Evals,Script} ->
-            if OTPRelease >= "26" ->
-                    %% The new way 26 and later)
+            if Rel >= 28 ->
+                    %% OTP 28+ requires the input key (cooked|raw|disabled).
+                    user_drv:start(#{initial_shell => noshell,
+                                     input => cooked});
+               Rel >= 26 ->
                     user_drv:start(#{initial_shell => noshell});
                true ->
-                    %% The old way before 26.
                     user:start()
             end,
             run_evals_script(Repl, Evals, Script)

--- a/test/lfe_init_SUITE.lfe
+++ b/test/lfe_init_SUITE.lfe
@@ -15,8 +15,6 @@
 ;; File    : lfe_init_SUITE.lfe
 ;; Purpose : Verify lfe -eval across OTP versions.
 
-(include-file "test_server.lfe")
-
 (defmodule lfe_init_SUITE
   "Verify that lfe -eval works across OTP versions."
   (export
@@ -76,8 +74,8 @@
 ;;; --- helpers ---
 
 (defun run-lfe-eval (config expr)
-  (let* ((lfe-bin (config 'lfe_bin config))
-         (lfe-root (config 'lfe_root config))
+  (let* ((lfe-bin (proplists:get_value 'lfe_bin config))
+         (lfe-root (proplists:get_value 'lfe_root config))
          (port (open_port
                 (tuple 'spawn_executable lfe-bin)
                 (list (tuple 'args (list "-eval" expr))

--- a/test/lfe_init_SUITE.lfe
+++ b/test/lfe_init_SUITE.lfe
@@ -95,20 +95,12 @@
       (catch (port_close port))
       (ct:fail (tuple 'timeout acc)))))
 
+;; This test must spawn bin/lfe as an external process, because the
+;; bug is specifically about how lfe_init:start/0 is invoked via
+;; -user lfe_init with -noshell, which is what bin/lfe sets up. We
+;; can't reproduce that calling convention from inside an
+;; already-running BEAM.
 (defun lfe-root-dir ()
-  (let* ((build-dir
-          (case (code:lib_dir 'lfe)
-            (`#(error bad_name)
-             (filename:dirname
-              (filename:dirname
-               (filename:dirname (code:which 'lfe_comp)))))
-            (dir dir)))
-         (abs-dir (filename:absname build-dir))
-         (project-root
-          (filename:dirname
-           (filename:dirname
-            (filename:dirname
-             (filename:dirname abs-dir))))))
-    (case (filelib:is_file (filename:join (list project-root "bin" "lfe")))
-      ('true project-root)
-      ('false abs-dir))))
+  (let* ((test-lib-dir (filename:absname (code:lib_dir 'lfe))) ; rebar3 test lib path
+         (dirs-to-root (lists:duplicate 4 "..")))              ; _build/<profile>/lib/lfe -> root
+    (filename:absname (filename:join (cons test-lib-dir dirs-to-root)))))

--- a/test/lfe_init_SUITE.lfe
+++ b/test/lfe_init_SUITE.lfe
@@ -1,0 +1,114 @@
+;; Copyright (c) 2026 Duncan McGreggor
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; File    : lfe_init_SUITE.lfe
+;; Purpose : Verify lfe -eval across OTP versions.
+
+(include-file "test_server.lfe")
+
+(defmodule lfe_init_SUITE
+  "Verify that lfe -eval works across OTP versions."
+  (export
+   (all 0) (suite 0) (groups 0)
+   (init_per_suite 1) (end_per_suite 1)
+   (eval_simple_expr 1)
+   (eval_io_output 1)
+   (eval_exit_status 1)
+   (eval_multiple_exprs 1)))
+
+(defun all ()
+  '(eval_simple_expr eval_io_output eval_exit_status eval_multiple_exprs))
+
+(defun suite ()
+  `(#(timetrap #(seconds 30))))
+
+(defun groups () '())
+
+(defun init_per_suite (config)
+  (let* ((root (lfe-root-dir))
+         (lfe-bin (filename:join (list root "bin" "lfe"))))
+    (case (filelib:is_file lfe-bin)
+      ('true
+       (lists:append
+        (list (tuple 'lfe_bin lfe-bin) (tuple 'lfe_root root))
+        config))
+      ('false
+       (tuple 'skip
+              (lists:flatten
+               (io_lib:format "lfe binary not found at ~s" (list lfe-bin))))))))
+
+(defun end_per_suite (_config) 'ok)
+
+;; Evaluate a simple arithmetic expression, verify output.
+(defun eval_simple_expr (config)
+  (let ((`#(0 #"3") (run-lfe-eval config
+                      "(io:format \"~w\" (list (+ 1 2))) (halt 0)")))
+    'ok))
+
+;; Verify that io:format output is captured correctly.
+(defun eval_io_output (config)
+  (let ((`#(0 #"hello world") (run-lfe-eval config
+                                "(io:format \"hello world\" ()) (halt 0)")))
+    'ok))
+
+;; Verify that a non-zero exit status propagates.
+(defun eval_exit_status (config)
+  (let ((`#(42 ,_) (run-lfe-eval config "(halt 42)")))
+    'ok))
+
+;; Verify that multiple -eval expressions are evaluated in order.
+(defun eval_multiple_exprs (config)
+  (let ((`#(0 #"ab") (run-lfe-eval config
+                       "(io:format \"a\" ()) (io:format \"b\" ()) (halt 0)")))
+    'ok))
+
+;;; --- helpers ---
+
+(defun run-lfe-eval (config expr)
+  (let* ((lfe-bin (config 'lfe_bin config))
+         (lfe-root (config 'lfe_root config))
+         (port (open_port
+                (tuple 'spawn_executable lfe-bin)
+                (list (tuple 'args (list "-eval" expr))
+                      (tuple 'env (list (tuple "ERL_LIBS" lfe-root)))
+                      'exit_status 'stderr_to_stdout 'binary 'hide))))
+    (collect-port port #"")))
+
+(defun collect-port (port acc)
+  (receive
+    (`#(,port #(data ,data))
+     (collect-port port (binary (acc binary) (data binary))))
+    (`#(,port #(exit_status ,status))
+     (tuple status (string:trim acc)))
+    (after 15000
+      (catch (port_close port))
+      (ct:fail (tuple 'timeout acc)))))
+
+(defun lfe-root-dir ()
+  (let* ((build-dir
+          (case (code:lib_dir 'lfe)
+            (`#(error bad_name)
+             (filename:dirname
+              (filename:dirname
+               (filename:dirname (code:which 'lfe_comp)))))
+            (dir dir)))
+         (abs-dir (filename:absname build-dir))
+         (project-root
+          (filename:dirname
+           (filename:dirname
+            (filename:dirname
+             (filename:dirname abs-dir))))))
+    (case (filelib:is_file (filename:join (list project-root "bin" "lfe")))
+      ('true project-root)
+      ('false abs-dir))))


### PR DESCRIPTION
Fixes #517 

LFE's CI matrix covers OTP 22 through 29. The `user_drv` / `user` interface has
three distinct shapes across that range, and the `input` key's type changed
between OTP 27 and 28, so a single `input => cooked` cannot be used across all
OTP 26+ versions:

| OTP | noshell startup API | `input` type |
|-----|---------------------|-------------|
| 22–25 | `user:start()` | N/A |
| 26–27 | `user_drv:start(#{initial_shell => noshell})` | `boolean()` (default `true`) |
| 28+ | `user_drv:start(#{initial_shell => noshell, input => cooked})` | `cooked \| raw \| disabled` (**no default**) |

Passing `input => cooked` on OTP 26–27 crashes with `case_clause` inside
`prim_tty:init_term/1`, which pattern-matches `input` against `true` and
`false` only. So the three eras need three branches.

The existing code uses string comparison (`OTPRelease >= "26"`), which works for
two-digit OTP versions (22–29) but fails for single-digit or three-digit
releases (`"9" > "28"` is `true`; `"100" > "28"` is `false`). Using
`list_to_integer/1` is more robust and costs nothing.