### PR TITLE
Fix lfe_init_SUITE ERL_LIBS to target the compiled lfe app

### DIFF
--- a/test/lfe_init_SUITE.lfe
+++ b/test/lfe_init_SUITE.lfe
@@ -35,11 +35,12 @@
 
 (defun init_per_suite (config)
   (let* ((root (lfe-root-dir))
-         (lfe-bin (filename:join (list root "bin" "lfe"))))
+         (lfe-bin (filename:join (list root "bin" "lfe")))
+         (erl-libs (lfe-erl-libs)))
     (case (filelib:is_file lfe-bin)
       ('true
        (lists:append
-        (list (tuple 'lfe_bin lfe-bin) (tuple 'lfe_root root))
+        (list (tuple 'lfe_bin lfe-bin) (tuple 'erl_libs erl-libs))
         config))
       ('false
        (tuple 'skip
@@ -75,11 +76,11 @@
 
 (defun run-lfe-eval (config expr)
   (let* ((lfe-bin (proplists:get_value 'lfe_bin config))
-         (lfe-root (proplists:get_value 'lfe_root config))
+         (erl-libs (proplists:get_value 'erl_libs config))
          (port (open_port
                 (tuple 'spawn_executable lfe-bin)
                 (list (tuple 'args (list "-eval" expr))
-                      (tuple 'env (list (tuple "ERL_LIBS" lfe-root)))
+                      (tuple 'env (list (tuple "ERL_LIBS" erl-libs)))
                       'exit_status 'stderr_to_stdout 'binary 'hide))))
     (collect-port port #"")))
 
@@ -102,3 +103,13 @@
   (let* ((test-lib-dir (filename:absname (code:lib_dir 'lfe))) ; rebar3 test lib path
          (dirs-to-root (lists:duplicate 4 "..")))              ; _build/<profile>/lib/lfe -> root
     (filename:absname (filename:join (cons test-lib-dir dirs-to-root)))))
+
+;; ERL_LIBS for the spawned bin/lfe must point at the OTP library
+;; directory that actually holds the compiled lfe application, i.e. the
+;; parent of code:lib_dir('lfe') (_build/<profile>/lib). Pointing it at
+;; the repo root instead only works when a matching profile happens to
+;; be pre-built (as CI does via `rebar3 compile`), so `rebar3 ct` alone
+;; would fail to find lfe_init. Deriving it from the running app makes
+;; the suite independent of which rebar3 profile is built.
+(defun lfe-erl-libs ()
+  (filename:dirname (filename:absname (code:lib_dir 'lfe))))


### PR DESCRIPTION
## Problem

`lfe_init_SUITE` fails locally under a bare `rebar3 ct` or a clean `make tests`, but is green in CI:

```
{undef,[{lfe_init,start,[],[]}, ...]}   %% kernel `user` child fails to start
```

## Root cause

The suite spawns `bin/lfe` and sets `ERL_LIBS` to the **repo root**, which is not a valid OTP library directory for the `lfe` app. The compiled beams (including `lfe_init.beam`) live in `_build/<profile>/lib/lfe/ebin`, while the root `ebin/` holds only `lfe.app`. So `bin/lfe` could only find `lfe_init` via its *fallback* rebar3 path, which defaults to the **`default`** profile.

CI's `builds` job runs `rebar3 compile` (populating `_build/default/lib/lfe/ebin`) **before** `make ct`, so the wrong `ERL_LIBS` was silently rescued by the default-profile fallback. A bare `rebar3 ct` — or `make tests`, which cleans `_build` and builds only the **test** profile — never populates the default profile, so `lfe_init` was absent from the resolved code path.

## Fix

Derive `ERL_LIBS` from the running app: the parent of `code:lib_dir('lfe')` is the actual `_build/<profile>/lib` dir containing the compiled `lfe` app. This makes the suite independent of which rebar3 profile happens to be pre-built. `bin/lfe` is still located from the repo root as before.

This is a **test-harness fix only** — the `lfe_init` / OTP-28 `user_drv` work from #518 is fine; `lfe -eval` genuinely works. The test was just pointed at the wrong library directory.

## Verification

- `rebar3 ct --suite test/lfe_init_SUITE` → 4/4 pass
- clean `make tests` → all 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)